### PR TITLE
Add SQLAlchemy models and DB init

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -3,6 +3,8 @@ import webbrowser
 import threading
 import os
 
+from .models import init_db
+
 app = Flask(__name__, static_folder='../frontend', static_url_path='')
 
 @app.route('/')
@@ -15,6 +17,7 @@ def open_browser():
 
 
 def run():
+    init_db()
     threading.Timer(1, open_browser).start()
     app.run()
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,29 @@
+from sqlalchemy import create_engine, Column, Integer, String, Float, Date, ForeignKey
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+
+engine = create_engine('sqlite:///tresoperso.db')
+SessionLocal = sessionmaker(bind=engine)
+Base = declarative_base()
+
+class Category(Base):
+    __tablename__ = 'categories'
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True, nullable=False)
+    transactions = relationship('Transaction', back_populates='category')
+
+class Transaction(Base):
+    __tablename__ = 'transactions'
+
+    id = Column(Integer, primary_key=True)
+    date = Column(Date, nullable=False)
+    label = Column(String, nullable=False)
+    amount = Column(Float, nullable=False)
+    category_id = Column(Integer, ForeignKey('categories.id'))
+
+    category = relationship('Category', back_populates='transactions')
+
+
+def init_db():
+    """Create database tables if they do not exist."""
+    Base.metadata.create_all(engine)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+SQLAlchemy


### PR DESCRIPTION
## Summary
- add SQLAlchemy dependency
- define Transaction and Category models
- create DB initialization function and call it when launching the app

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest --maxfail=1 -q`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685ba588ea2c832f900f7fb0de2ec6cb