### PR TITLE
Add authentication via Flask-Login

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,9 +1,21 @@
 from sqlalchemy import create_engine, Column, Integer, String, Float, Date, ForeignKey
 from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+from flask_login import UserMixin
+from werkzeug.security import generate_password_hash
 
 engine = create_engine('sqlite:///tresoperso.db')
 SessionLocal = sessionmaker(bind=engine)
 Base = declarative_base()
+
+
+class User(UserMixin, Base):
+    """Simple user account."""
+
+    __tablename__ = 'users'
+
+    id = Column(Integer, primary_key=True)
+    username = Column(String, unique=True, nullable=False)
+    password = Column(String, nullable=False)
 
 class Category(Base):
     __tablename__ = 'categories'
@@ -27,3 +39,11 @@ class Transaction(Base):
 def init_db():
     """Create database tables if they do not exist."""
     Base.metadata.create_all(engine)
+
+    # Create a default user if none exists
+    session = SessionLocal()
+    if not session.query(User).first():
+        user = User(username='admin', password=generate_password_hash('admin'))
+        session.add(user)
+        session.commit()
+    session.close()

--- a/frontend/app.jsx
+++ b/frontend/app.jsx
@@ -76,4 +76,52 @@ function TransactionTable() {
   );
 }
 
-ReactDOM.render(<TransactionTable />, document.getElementById('root'));
+function LoginForm({ onLogin }) {
+  const [username, setUsername] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  const [error, setError] = React.useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    fetch('/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    })
+      .then(r => r.ok ? r.json() : Promise.reject())
+      .then(() => onLogin())
+      .catch(() => setError('Identifiants invalides'));
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Utilisateur" />
+      </div>
+      <div>
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Mot de passe" />
+      </div>
+      {error && <div style={{color: 'red'}}>{error}</div>}
+      <button type="submit">Connexion</button>
+    </form>
+  );
+}
+
+function App() {
+  const [loggedIn, setLoggedIn] = React.useState(false);
+
+  React.useEffect(() => {
+    fetch('/me')
+      .then(r => r.ok && r.json())
+      .then(data => {
+        if (data && data.username) setLoggedIn(true);
+      });
+  }, []);
+
+  if (!loggedIn) {
+    return <LoginForm onLogin={() => setLoggedIn(true)} />;
+  }
+  return <TransactionTable />;
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 SQLAlchemy
+Flask-Login


### PR DESCRIPTION
## Summary
- implement User model and default admin user
- secure CSV import & transaction list with login
- add login/logout/me endpoints
- create simple login form in React
- include Flask-Login dependency

## Testing
- `python -m py_compile backend/*.py run.py`

------
https://chatgpt.com/codex/tasks/task_e_685ba85f2578832fa46db9923542a5b8