### PR TITLE
Fix index loading path

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,9 +1,3 @@
-from flask import Flask, send_from_directory
-import webbrowser
-import threading
-import os
-
-app = Flask(__name__, static_folder='../frontend', static_url_path='')
 from flask import Flask, send_from_directory, request, jsonify
 from flask_login import LoginManager, login_user, login_required, logout_user, current_user
 from werkzeug.security import check_password_hash
@@ -16,7 +10,13 @@ from sqlalchemy import func
 
 from .models import init_db, SessionLocal, Transaction, Category, Rule, User
 
-app = Flask(__name__, static_folder='../frontend', static_url_path='')
+# Compute the absolute path to the frontend directory so Flask can
+# reliably serve the static files no matter where the application is
+# started from.
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+FRONTEND_DIR = os.path.join(BASE_DIR, '..', 'frontend')
+
+app = Flask(__name__, static_folder=FRONTEND_DIR, static_url_path='')
 app.secret_key = os.environ.get('SECRET_KEY', 'dev-secret')
 
 login_manager = LoginManager(app)
@@ -34,13 +34,6 @@ def load_user(user_id):
 def index():
     return send_from_directory(app.static_folder, 'index.html')
 
-
-def open_browser():
-    """Open the application homepage in the default web browser."""
-    webbrowser.open_new('http://localhost:5000/')
-
-
-def run():
 
 @app.route('/login', methods=['POST'])
 def login():

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tresoperso</title>
-</head>
-<body>
-    <h1>Bienvenue sur Tresoperso</h1>
-    <p>Application de suivi de trésorerie personnelle.</p>
     <style>
         table { border-collapse: collapse; width: 100%; }
         th, td { border: 1px solid #ccc; padding: 4px; }


### PR DESCRIPTION
## Summary
- compute absolute frontend path in `backend/app.py`
- ensure index page loads regardless of working directory

## Testing
- `python -m py_compile backend/app.py run.py backend/models.py`
- `python run.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685bbbbf2704832f9048cbefef8c0aca