### PR TITLE
Include frontend in packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .PHONY: package
 
 package:
-	pyinstaller --onefile run.py
+        pyinstaller --onefile --add-data "frontend:frontend" run.py

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ Pour créer un exécutable autonome pour macOS, PyInstaller est utilisé. Un
 make package
 ```
 
-Cette commande lance `pyinstaller --onefile run.py` et génère le binaire dans
-`dist/run`. La construction doit être effectuée sur macOS afin d'obtenir un
+Cette commande lance `pyinstaller --onefile --add-data "frontend:frontend" run.py`
+et génère le binaire dans `dist/run`. La construction doit être effectuée sur
+macOS afin d'obtenir un
 exécutable natif.
 
 ## Licence


### PR DESCRIPTION
## Summary
- update `make package` to bundle the `frontend` directory via `--add-data`
- document packaging command in README

## Testing
- `pip install pyinstaller` *(fails: Cannot connect to proxy)*
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685bd13938e0832fb4759fcca5a9a493