### PR TITLE
Add transaction type and payment method support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ supprimé en cas de réinitialisation souhaitée.
 
 Pour la BNP : Les champs du CSV doivent être séparés par des point-virgules (`;`). 
 Les fichiers de la bnp ne comportent pas d'entete de colonnes. la premiere ligne decrit le compte bancaire. A partir de la deuxieme ligne se trouvent les transactions.
-Elles sont au format :`date`, `type de transaction`,`moyen de paiement`,`libellé` et
-`montant`.
+Elles sont au format :`date`, `type de transaction`, `moyen de paiement`, `libellé` et
+`montant`. Les colonnes `type de transaction` et `moyen de paiement` sont
+désormais enregistrées dans la base pour chaque opération.
 
 Les montants peuvent contenir un espace comme séparateur de milliers et
 utiliser soit la virgule soit le point pour indiquer les décimales.

--- a/backend/app.py
+++ b/backend/app.py
@@ -74,8 +74,8 @@ def parse_csv(content):
     use a semicolon (``;``) as delimiter. The first line contains account
     information and must be ignored. Each transaction line is expected to
     contain the fields ``date`` , ``type`` , ``moyen de paiement`` , ``libellé``
-    and ``montant`` in that order. Only the ``date``, ``libellé`` and
-    ``montant`` columns are used.
+    and ``montant`` in that order. The ``type`` and ``moyen de paiement``
+    columns are now stored alongside ``date``, ``libellé`` and ``montant``.
 
     Duplicate rows based on (date, label, amount) are ignored and reported as
     errors.
@@ -97,6 +97,8 @@ def parse_csv(content):
             continue
 
         date_str = row[0]
+        tx_type = row[1]
+        payment_method = row[2]
         label = row[3]
         amount_str = row[4]
 
@@ -127,7 +129,13 @@ def parse_csv(content):
             continue
         seen.add(key)
 
-        transactions.append({'date': date, 'label': label.strip(), 'amount': amount})
+        transactions.append({
+            'date': date,
+            'tx_type': tx_type.strip(),
+            'payment_method': payment_method.strip(),
+            'label': label.strip(),
+            'amount': amount
+        })
 
     return transactions, errors
 
@@ -174,7 +182,11 @@ def import_csv():
                     break
 
             session.add(Transaction(
-                date=t['date'], label=t['label'], amount=t['amount'],
+                date=t['date'],
+                tx_type=t['tx_type'],
+                payment_method=t['payment_method'],
+                label=t['label'],
+                amount=t['amount'],
                 category_id=category_id
             ))
             imported += 1
@@ -244,6 +256,8 @@ def list_transactions():
         results.append({
             'id': t.id,
             'date': t.date.isoformat(),
+            'tx_type': t.tx_type,
+            'payment_method': t.payment_method,
             'label': t.label,
             'amount': t.amount,
             'category': t.category.name if t.category else None


### PR DESCRIPTION
## Summary
- extend `Transaction` model with `tx_type` and `payment_method`
- ensure DB upgrade adds the new columns
- parse these fields when importing CSV files
- store the new fields when inserting transactions
- include them in `/transactions` responses
- document CSV columns in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bf1457630832fa71b5979b48b5736