### PR TITLE
Display transaction type and payment method

### DIFF
--- a/frontend/app.jsx
+++ b/frontend/app.jsx
@@ -56,6 +56,8 @@ function TransactionTable() {
         <thead>
           <tr>
             <th>Date</th>
+            <th>Type</th>
+            <th>Moyen de paiement</th>
             <th>Libellé</th>
             <th>Montant</th>
             <th>Catégorie</th>
@@ -65,6 +67,8 @@ function TransactionTable() {
           {transactions.map(t => (
             <tr key={t.id}>
               <td>{t.date}</td>
+              <td>{t.tx_type}</td>
+              <td>{t.payment_method}</td>
               <td>{t.label}</td>
               <td>{t.amount}</td>
               <td>{t.category || ''}</td>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -45,6 +45,8 @@
             <thead>
                 <tr>
                     <th>Date</th>
+                    <th>Type</th>
+                    <th>Moyen de paiement</th>
                     <th>Libellé</th>
                     <th>Montant</th>
                     <th>Catégorie</th>
@@ -72,7 +74,7 @@
             tbody.innerHTML = '';
             data.forEach(t => {
                 const tr = document.createElement('tr');
-                tr.innerHTML = `<td>${t.date}</td><td>${t.label}</td><td>${t.amount}</td><td>${t.category || ''}</td>`;
+                tr.innerHTML = `<td>${t.date}</td><td>${t.tx_type}</td><td>${t.payment_method}</td><td>${t.label}</td><td>${t.amount}</td><td>${t.category || ''}</td>`;
                 tbody.appendChild(tr);
             });
         }


### PR DESCRIPTION
## Summary
- show type and payment method in the React table
- add matching columns to the plain HTML page

## Testing
- `python -m py_compile backend/app.py backend/models.py`


------
https://chatgpt.com/codex/tasks/task_e_685bf222a2cc832fb436f263eb8137ae