### PR TITLE
Add collapsible sidebar menus

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -51,7 +51,12 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
 }
 #app { display: flex; }
 #sidebar { width: 200px; border-right: 1px solid var(--border-color); padding-right: 10px; }
-#sidebar button { display: block; width: 100%; margin: 4px 0; }
+#sidebar ul { list-style: none; padding-left: 0; }
+#sidebar li { margin-bottom: 4px; }
+#sidebar .menu-header { cursor: pointer; font-weight: bold; padding: 4px 0; }
+#sidebar .submenu { list-style: none; padding-left: 15px; max-height: 0; overflow: hidden; transition: max-height 0.3s ease; }
+#sidebar li.open > .submenu { max-height: 1000px; }
+#sidebar .submenu button { display: block; width: 100%; margin: 4px 0; }
 #content { flex-grow: 1; padding-left: 10px; }
 
 .font-roboto { --font-family: 'Roboto', Arial, Geneva, sans-serif; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,10 +17,27 @@
     </form>
     <div id="app" style="display:none;">
         <div id="sidebar">
-            <button data-target="transactions-section">Transactions</button>
-            <button data-target="stats-section">Statistiques</button>
-            <button data-target="projection-section">Projection</button>
-            <button data-target="settings-section">Paramètres</button>
+            <ul class="menu">
+                <li class="open">
+                    <div class="menu-header">Transactions</div>
+                    <ul class="submenu">
+                        <li><button data-target="transactions-section">Transactions</button></li>
+                    </ul>
+                </li>
+                <li>
+                    <div class="menu-header">Statistiques</div>
+                    <ul class="submenu">
+                        <li><button data-target="stats-section">Statistiques</button></li>
+                        <li><button data-target="projection-section">Projection</button></li>
+                    </ul>
+                </li>
+                <li>
+                    <div class="menu-header">Paramètres</div>
+                    <ul class="submenu">
+                        <li><button data-target="settings-section">Paramètres</button></li>
+                    </ul>
+                </li>
+            </ul>
         </div>
         <div id="content">
             <section id="transactions-section">
@@ -513,12 +530,18 @@
         });
 
         const sectionIds = ['transactions-section', 'stats-section', 'projection-section', 'settings-section'];
-        document.querySelectorAll('#sidebar button').forEach(btn => {
+        document.querySelectorAll('#sidebar .submenu button').forEach(btn => {
             btn.addEventListener('click', () => {
                 const target = btn.dataset.target;
                 sectionIds.forEach(id => {
                     document.getElementById(id).style.display = id === target ? 'block' : 'none';
                 });
+            });
+        });
+
+        document.querySelectorAll('#sidebar .menu-header').forEach(header => {
+            header.addEventListener('click', () => {
+                header.parentElement.classList.toggle('open');
             });
         });
 


### PR DESCRIPTION
## Summary
- show a nested list in the sidebar
- toggle submenu visibility in JavaScript
- style the sidebar hierarchy and add transitions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c03ea6bf8832faf9c8fee246a9b97