### PR TITLE
Add interactive and selected theme colors

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -8,6 +8,8 @@
     --text-color: #000000;
     --border-color: #ccc;
     --popup-bg: #fff;
+    --interactive-color: #0066cc;
+    --selected-color: #cce5ff;
 }
 
 body {
@@ -58,6 +60,29 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
 #sidebar li.open > .submenu { max-height: 1000px; }
 #sidebar .submenu button { display: block; width: 100%; margin: 4px 0; }
 #content { flex-grow: 1; padding-left: 10px; }
+
+a {
+    color: var(--interactive-color);
+}
+
+button,
+input[type="submit"],
+input[type="button"] {
+    background-color: var(--interactive-color);
+    color: #fff;
+    border: none;
+    padding: 4px 8px;
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+    accent-color: var(--interactive-color);
+}
+
+#sidebar .submenu button.selected,
+tr.selected {
+    background-color: var(--selected-color);
+}
 
 .font-roboto { --font-family: 'Roboto', Arial, Geneva, sans-serif; }
 .font-arial { --font-family: 'Arial', sans-serif; }

--- a/frontend/dark.css
+++ b/frontend/dark.css
@@ -3,4 +3,6 @@
     --text-color: #f0f0f0;
     --border-color: #555;
     --popup-bg: #2a2a2a;
+    --interactive-color: #66b3ff;
+    --selected-color: #004c99;
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -530,14 +530,20 @@
         });
 
         const sectionIds = ['transactions-section', 'stats-section', 'projection-section', 'settings-section'];
-        document.querySelectorAll('#sidebar .submenu button').forEach(btn => {
+        const sidebarButtons = document.querySelectorAll('#sidebar .submenu button');
+        sidebarButtons.forEach(btn => {
             btn.addEventListener('click', () => {
                 const target = btn.dataset.target;
                 sectionIds.forEach(id => {
                     document.getElementById(id).style.display = id === target ? 'block' : 'none';
                 });
+                sidebarButtons.forEach(b => b.classList.remove('selected'));
+                btn.classList.add('selected');
             });
         });
+        if (sidebarButtons.length) {
+            sidebarButtons[0].classList.add('selected');
+        }
 
         document.querySelectorAll('#sidebar .menu-header').forEach(header => {
             header.addEventListener('click', () => {

--- a/frontend/light.css
+++ b/frontend/light.css
@@ -3,4 +3,6 @@
     --text-color: #000000;
     --border-color: #ccc;
     --popup-bg: #ffffff;
+    --interactive-color: #0066cc;
+    --selected-color: #cce5ff;
 }


### PR DESCRIPTION
## Summary
- add `--interactive-color` and `--selected-color` variables to `base.css`
- style links, buttons and selected elements using these colors
- define color values for both light and dark themes
- highlight active sidebar entries in the UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c04eff0c0832fbe8027f4917a02e6