### PR TITLE
Add DB file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.py[cod]
 dist/
+tresoperso.db


### PR DESCRIPTION
## Summary
- ignore `tresoperso.db` so database files aren't committed by accident

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c09e782b0832fab9f97352c5e2979