### PR TITLE
Rework navigation layout

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -51,15 +51,15 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
     padding: 10px;
     border: 1px solid var(--border-color);
 }
-#app { display: flex; }
-#sidebar { width: 200px; border-right: 1px solid var(--border-color); padding-right: 10px; }
-#sidebar ul { list-style: none; padding-left: 0; }
-#sidebar li { margin-bottom: 4px; }
-#sidebar .menu-header { cursor: pointer; font-weight: bold; padding: 4px 0; }
-#sidebar .submenu { list-style: none; padding-left: 15px; max-height: 0; overflow: hidden; transition: max-height 0.3s ease; }
-#sidebar li.open > .submenu { max-height: 1000px; }
-#sidebar .submenu button { display: block; width: 100%; margin: 4px 0; }
-#content { flex-grow: 1; padding-left: 10px; }
+#app { display: flex; flex-direction: column; }
+#navbar { position: fixed; top: 0; left: 0; right: 0; border-bottom: 1px solid var(--border-color); background: var(--bg-color); z-index: 1000; }
+#navbar ul { list-style: none; margin: 0; padding: 0; display: flex; }
+#navbar li { position: relative; margin-right: 20px; }
+#navbar .menu-header { cursor: pointer; font-weight: bold; padding: 4px 8px; }
+#navbar .submenu { list-style: none; padding: 0; position: absolute; top: 100%; left: 0; background: var(--bg-color); border: 1px solid var(--border-color); display: none; }
+#navbar li.open > .submenu { display: block; }
+#navbar .submenu button { display: block; width: 100%; padding: 4px 8px; }
+#content { flex-grow: 1; padding: 60px 10px 0 10px; }
 
 a {
     color: var(--interactive-color);
@@ -85,9 +85,11 @@ input[type="radio"] {
 
 }
 
-#sidebar .submenu button.selected,
+#navbar .submenu button.selected,
+.menu-header.selected,
 tr.selected {
-    background-color: var(--selected-color);
+    color: #fc9107;
+    background-color: var(--bg-color);
 }
 
 .font-roboto { --font-family: 'Roboto', Arial, Geneva, sans-serif; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,14 +9,13 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
-    <h1>Tresoperso</h1>
     <form id="login-form">
         <input type="text" id="username" placeholder="Utilisateur" required />
         <input type="password" id="password" placeholder="Mot de passe" required />
         <button type="submit">Connexion</button>
     </form>
     <div id="app" style="display:none;">
-        <div id="sidebar">
+        <nav id="navbar">
             <ul class="menu">
                 <li class="open">
                     <div class="menu-header">Transactions</div>
@@ -25,10 +24,10 @@
                     </ul>
                 </li>
                 <li>
-                    <div class="menu-header">Statistiques</div>
+                    <div class="menu-header">Analyses</div>
                     <ul class="submenu">
                         <li><button data-target="stats-section">Statistiques</button></li>
-                        <li><button data-target="projection-section">Projection</button></li>
+                        <li><button data-target="projection-section">Projections</button></li>
                     </ul>
                 </li>
                 <li>
@@ -38,8 +37,9 @@
                     </ul>
                 </li>
             </ul>
-        </div>
+        </nav>
         <div id="content">
+            <h1>Tresoperso</h1>
             <section id="transactions-section">
                 <form id="upload-form">
                     <input type="file" id="csv-file" name="file" accept=".csv" required />
@@ -530,7 +530,7 @@
         });
 
         const sectionIds = ['transactions-section', 'stats-section', 'projection-section', 'settings-section'];
-        const sidebarButtons = document.querySelectorAll('#sidebar .submenu button');
+        const sidebarButtons = document.querySelectorAll('#navbar .submenu button');
         sidebarButtons.forEach(btn => {
             btn.addEventListener('click', () => {
                 const target = btn.dataset.target;
@@ -545,7 +545,7 @@
             sidebarButtons[0].classList.add('selected');
         }
 
-        document.querySelectorAll('#sidebar .menu-header').forEach(header => {
+        document.querySelectorAll('#navbar .menu-header').forEach(header => {
             header.addEventListener('click', () => {
                 header.parentElement.classList.toggle('open');
             });


### PR DESCRIPTION
## Summary
- move sidebar menu into a fixed top navbar
- rename "Statistiques" menu to "Analyses" and keep its submenus
- update styles so selected items are orange with a transparent background

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c119ba7ac832f8978851a5f6fdcc8