### PR TITLE
Improve settings layout and transaction table

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -631,6 +631,17 @@ def rules(rule_id=None):
     return jsonify({'message': 'deleted'})
 
 
+@app.route('/reset', methods=['POST'])
+@login_required
+def reset():
+    """Delete all transactions from the database."""
+    session = SessionLocal()
+    session.query(Transaction).delete()
+    session.commit()
+    session.close()
+    return jsonify({'message': 'reset'})
+
+
 def open_browser():
     webbrowser.open_new('http://localhost:5000')
 

--- a/frontend/base.css
+++ b/frontend/base.css
@@ -35,6 +35,38 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
 #transactions-table td:nth-child(9) {
     min-width: 90px;
 }
+#transactions-table th:nth-child(1),
+#transactions-table td:nth-child(1) {
+    text-align: right;
+}
+#transactions-table th:nth-child(5),
+#transactions-table td:nth-child(5) {
+    text-align: right;
+}
+#transactions-table th:nth-child(8),
+#transactions-table td:nth-child(8),
+#transactions-table th:nth-child(9),
+#transactions-table td:nth-child(9) {
+    text-align: center;
+}
+
+#catsubs-container {
+    display: flex;
+    gap: 20px;
+}
+.settings-col { flex: 1; }
+
+#categories-list li,
+#subcategories-list li,
+#rules-list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 4px;
+}
+#categories-list li button,
+#subcategories-list li button,
+#rules-list li button { margin-left: 4px; }
 .overlay {
     position: fixed;
     top: 0;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -80,24 +80,29 @@
             </section>
 
             <section id="settings-section" style="display:none;">
-                <h2>Catégories</h2>
-                <form id="category-form">
-                    <input type="hidden" id="category-id" />
-                    <input type="text" id="category-name" placeholder="Nom" required />
-                    <input type="color" id="category-color" value="#000000" />
-                    <button type="submit">Enregistrer</button>
-                </form>
-                <ul id="categories-list"></ul>
-
-                <h3>Sous-catégories</h3>
-                <form id="subcategory-form">
-                    <input type="hidden" id="subcategory-id" />
-                    <input type="text" id="subcategory-name" placeholder="Nom" required />
-                    <select id="subcategory-category"></select>
-                    <input type="color" id="subcategory-color" value="#000000" />
-                    <button type="submit">Enregistrer</button>
-                </form>
-                <ul id="subcategories-list"></ul>
+                <div id="catsubs-container">
+                    <div class="settings-col">
+                        <h2>Catégories</h2>
+                        <form id="category-form">
+                            <input type="hidden" id="category-id" />
+                            <input type="text" id="category-name" placeholder="Nom" required />
+                            <input type="color" id="category-color" value="#000000" />
+                            <button type="submit">Enregistrer</button>
+                        </form>
+                        <ul id="categories-list"></ul>
+                    </div>
+                    <div class="settings-col">
+                        <h3>Sous-catégories</h3>
+                        <form id="subcategory-form">
+                            <input type="hidden" id="subcategory-id" />
+                            <input type="text" id="subcategory-name" placeholder="Nom" required />
+                            <select id="subcategory-category"></select>
+                            <input type="color" id="subcategory-color" value="#000000" />
+                            <button type="submit">Enregistrer</button>
+                        </form>
+                        <ul id="subcategories-list"></ul>
+                    </div>
+                </div>
 
                 <h2>Règles</h2>
                 <form id="rule-form">
@@ -122,6 +127,9 @@
                     <option value="arial">Arial</option>
                     <option value="geneva">Geneva</option>
                 </select>
+
+                <h2>RESET</h2>
+                <button id="reset-transactions">Effacer les transactions</button>
             </section>
         </div>
 
@@ -142,6 +150,18 @@
         let categoriesData = [];
         let subcategoriesData = [];
 
+        function findCategory(id) {
+            return categoriesData.find(c => String(c.id) === String(id));
+        }
+
+        function findSubcategory(id) {
+            return subcategoriesData.find(s => String(s.id) === String(id));
+        }
+
+        function formatAmount(v) {
+            return (v || 0).toLocaleString('fr-FR', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+        }
+
         async function fetchTransactions() {
             const resp = await fetch('/transactions');
             if (!resp.ok) return;
@@ -150,7 +170,9 @@
             tbody.innerHTML = '';
             data.forEach(t => {
                 const tr = document.createElement('tr');
-                tr.innerHTML = `<td>${t.date}</td><td>${t.type}</td><td>${t.payment_method}</td><td>${t.label}</td><td>${t.amount}</td>`;
+                const type = t.type || '';
+                const pay = t.payment_method || '';
+                tr.innerHTML = `<td>${t.date}</td><td>${type}</td><td>${pay}</td><td>${t.label}</td><td>${formatAmount(t.amount)}</td>`;
 
                 const catCell = document.createElement('td');
                 const catBtn = document.createElement('button');
@@ -509,8 +531,10 @@
             const val = document.getElementById('popup-category-select').value;
             const resp = await fetch('/transactions/' + id, { method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({ category_id: val }) });
             if (resp.ok) {
+                const cat = findCategory(val);
+                currentCatBtn.dataset.current = val;
+                currentCatBtn.innerHTML = cat ? `<span style="color:${cat.color}">${cat.name}</span>` : '(Aucune)';
                 fetchTransactions();
-
             }
             catOverlay.style.display = 'none';
             currentCatBtn = null;
@@ -522,8 +546,10 @@
             const val = document.getElementById('popup-subcategory-select').value;
             const resp = await fetch('/transactions/' + id, { method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({ subcategory_id: val }) });
             if (resp.ok) {
+                const sub = findSubcategory(val);
+                currentSubBtn.dataset.current = val;
+                currentSubBtn.innerHTML = sub ? `<span style="color:${sub.color}">${sub.category} - ${sub.name}</span>` : '(Aucune)';
                 fetchTransactions();
-
             }
             subOverlay.style.display = 'none';
             currentSubBtn = null;
@@ -572,6 +598,16 @@
         fontSelect.addEventListener('change', () => {
             localStorage.setItem('font', fontSelect.value);
             applyPreferences();
+        });
+
+        document.getElementById('reset-transactions').addEventListener('click', async () => {
+            if (!confirm('Confirmer la suppression de toutes les transactions ?')) return;
+            const resp = await fetch('/reset', {method: 'POST'});
+            if (resp.ok) {
+                fetchTransactions();
+                fetchStats();
+                fetchProjection();
+            }
         });
 
         applyPreferences();


### PR DESCRIPTION
## Summary
- display categories and subcategories in two columns
- add reset action to wipe transactions
- align settings list buttons with flexbox
- format amounts and fix table alignment
- allow immediate update of category and subcategory selections

## Testing
- `python -m py_compile backend/*.py run.py`

------
https://chatgpt.com/codex/tasks/task_e_685c15ad35cc832faf6e04a929e565f3