### PR TITLE
Add bank account management

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -38,6 +38,16 @@ class Subcategory(Base):
     category = relationship('Category', back_populates='subcategories')
     transactions = relationship('Transaction', back_populates='subcategory')
 
+class BankAccount(Base):
+    __tablename__ = 'bank_accounts'
+
+    id = Column(Integer, primary_key=True)
+    account_type = Column(String)
+    number = Column(String)
+    export_date = Column(Date)
+
+    transactions = relationship('Transaction', back_populates='account')
+
 class Transaction(Base):
     __tablename__ = 'transactions'
 
@@ -47,6 +57,7 @@ class Transaction(Base):
     amount = Column(Float, nullable=False)
     tx_type = Column(String)
     payment_method = Column(String)
+    bank_account_id = Column(Integer, ForeignKey('bank_accounts.id'))
     category_id = Column(Integer, ForeignKey('categories.id'))
     subcategory_id = Column(Integer, ForeignKey('subcategories.id'))
     reconciled = Column(Boolean, default=False)
@@ -54,6 +65,7 @@ class Transaction(Base):
 
     category = relationship('Category', back_populates='transactions')
     subcategory = relationship('Subcategory', back_populates='transactions')
+    account = relationship('BankAccount', back_populates='transactions')
 
 
 class Rule(Base):
@@ -86,6 +98,8 @@ def init_db():
             conn.execute(text('ALTER TABLE transactions ADD COLUMN reconciled INTEGER DEFAULT 0'))
         if 'to_analyze' not in cols:
             conn.execute(text('ALTER TABLE transactions ADD COLUMN to_analyze INTEGER DEFAULT 1'))
+        if 'bank_account_id' not in cols:
+            conn.execute(text('ALTER TABLE transactions ADD COLUMN bank_account_id INTEGER'))
 
         info = conn.execute(text('PRAGMA table_info(categories)')).fetchall()
         cols = {row[1] for row in info}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -46,6 +46,14 @@
                     <button type="submit">Importer CSV</button>
                 </form>
 
+                <div id="account-controls">
+                    <label for="account-select">Compte :</label>
+                    <select id="account-select">
+                        <option value="">(Tous)</option>
+                    </select>
+                    <span id="account-info"></span>
+                </div>
+
                 <h2>Transactions</h2>
                 <table id="transactions-table">
                     <thead>
@@ -158,6 +166,8 @@
     <script>
         let categoriesData = [];
         let subcategoriesData = [];
+        let accountsData = [];
+        let selectedAccountId = '';
 
         function findCategory(id) {
             return categoriesData.find(c => String(c.id) === String(id));
@@ -171,10 +181,35 @@
             return (v || 0).toLocaleString('fr-FR', {minimumFractionDigits: 2, maximumFractionDigits: 2});
         }
 
+        function updateAccountDropdown() {
+            const select = document.getElementById('account-select');
+            select.innerHTML = '<option value="">(Tous)</option>';
+            accountsData.forEach(a => {
+                const opt = document.createElement('option');
+                opt.value = a.id;
+                opt.textContent = `${a.account_type} ${a.number}`.trim();
+                select.appendChild(opt);
+            });
+            select.value = selectedAccountId;
+        }
+
+        function displayAccountInfo() {
+            const info = document.getElementById('account-info');
+            const acc = accountsData.find(a => String(a.id) === String(selectedAccountId));
+            if (acc) {
+                const date = acc.export_date ? ` - export ${acc.export_date}` : '';
+                info.textContent = `${acc.account_type} ${acc.number}${date}`.trim();
+            } else {
+                info.textContent = '';
+            }
+        }
+
         async function fetchTransactions() {
-            const resp = await fetch('/transactions');
+            const url = selectedAccountId ? `/transactions?account_id=${selectedAccountId}` : '/transactions';
+            const resp = await fetch(url);
             if (!resp.ok) return;
             const data = await resp.json();
+            displayAccountInfo();
             const tbody = document.querySelector('#transactions-table tbody');
             tbody.innerHTML = '';
             data.forEach(t => {
@@ -270,6 +305,8 @@
             if (resp.ok) {
                 document.getElementById('login-form').style.display = 'none';
                 document.getElementById('app').style.display = 'block';
+                updateAccountDropdown();
+                displayAccountInfo();
                 fetchTransactions();
                 fetchCategories();
                 fetchSubcategories();
@@ -291,8 +328,15 @@
             const data = await resp.json().catch(() => ({}));
             if (resp.ok) {
                 fileInput.value = '';
+                if (data.account) {
+                    const exists = accountsData.some(a => String(a.id) === String(data.account.id));
+                    if (!exists) accountsData.push(data.account);
+                    selectedAccountId = data.account.id;
+                    updateAccountDropdown();
+                    displayAccountInfo();
+                }
                 if (data.duplicates && data.duplicates.length) {
-                    showDuplicates(data.duplicates);
+                    showDuplicates(data.duplicates, data.account ? data.account.id : '');
                 } else {
                     fetchTransactions();
                     fetchStats();
@@ -596,10 +640,11 @@
         catOverlay.addEventListener('click', e => { if (e.target === catOverlay) catOverlay.style.display = 'none'; });
         subOverlay.addEventListener('click', e => { if (e.target === subOverlay) subOverlay.style.display = 'none'; });
 
-        function showDuplicates(dups) {
+        function showDuplicates(dups, accountId) {
             const list = document.getElementById('duplicate-list');
             list.innerHTML = '';
             dupOverlay.dataset.rows = JSON.stringify(dups);
+            dupOverlay.dataset.accountId = accountId || '';
             dups.forEach((d, idx) => {
                 const li = document.createElement('li');
                 const cb = document.createElement('input');
@@ -631,7 +676,7 @@
             const resp = await fetch('/import/confirm', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({ transactions: selected })
+                body: JSON.stringify({ transactions: selected, account_id: dupOverlay.dataset.accountId })
             });
             const data = await resp.json().catch(() => ({}));
             if (resp.ok) {
@@ -710,6 +755,7 @@
         const themeSelect = document.getElementById('theme-select');
         const fontSelect = document.getElementById('font-select');
         const themeLink = document.getElementById('theme-link');
+        const accountSelect = document.getElementById('account-select');
 
         function applyPreferences() {
             const theme = localStorage.getItem('theme') || 'light';
@@ -728,6 +774,11 @@
         fontSelect.addEventListener('change', () => {
             localStorage.setItem('font', fontSelect.value);
             applyPreferences();
+        });
+
+        accountSelect.addEventListener('change', () => {
+            selectedAccountId = accountSelect.value;
+            fetchTransactions();
         });
 
         document.getElementById('reset-transactions').addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- create `BankAccount` model and link it to transactions
- parse account info from CSVs on import
- store transactions with associated account
- filter transactions by account
- display/import account information in the frontend

## Testing
- `python -m py_compile backend/app.py backend/models.py`

------
https://chatgpt.com/codex/tasks/task_e_685c204585c8832f8dd3b5925ccaddfd