### PR TITLE
Fix menu button borders

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -87,10 +87,20 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
 #navbar { position: fixed; top: 0; left: 0; right: 0; border-bottom: 1px solid var(--border-color); background: var(--bg-color); z-index: 1000; }
 #navbar ul { list-style: none; margin: 0; padding: 0; display: flex; }
 #navbar li { position: relative; margin-right: 20px; }
-#navbar .menu-header { cursor: pointer; font-weight: bold; padding: 4px 8px; }
+#navbar .menu-header {
+    cursor: pointer;
+    font-weight: bold;
+    padding: 4px 8px;
+    border: none;
+}
 #navbar .submenu { list-style: none; padding: 0; position: absolute; top: 100%; left: 0; background: var(--bg-color); border: 1px solid var(--border-color); display: none; }
 #navbar li.open > .submenu { display: block; }
-#navbar .submenu button { display: block; width: 100%; padding: 4px 8px; }
+#navbar .submenu button {
+    display: block;
+    width: 100%;
+    padding: 4px 8px;
+    border: none;
+}
 #content { flex-grow: 1; padding: 60px 10px 0 10px; }
 
 a {
@@ -108,6 +118,12 @@ input[type="button"] {
     padding: 4px 8px;
     cursor: pointer;
 
+}
+
+/* Ensure menu buttons have no visible border */
+#navbar .submenu button,
+.menu-header {
+    border: none;
 }
 
 input[type="checkbox"],


### PR DESCRIPTION
## Summary
- ensure navbar menu buttons don't show borders

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c22772ee8832fba63e418be5082a1