### PR TITLE
Improve transactions table responsive design

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -20,10 +20,15 @@ body {
 
 table { border-collapse: collapse; width: 100%; }
 th, td { border: 1px solid var(--border-color); padding: 4px; }
-#transactions-table { width: 90%; }
+#transactions-table {
+    width: 90%;
+    font-size: 0.85rem;
+}
+#transactions-table th:nth-child(4),
 #transactions-table td:nth-child(4) {
     white-space: normal;
     word-break: break-word;
+    min-width: 150px;
 }
 #transactions-table th:nth-child(1),
 #transactions-table td:nth-child(1),
@@ -143,3 +148,9 @@ tr.selected {
 .font-roboto { --font-family: 'Roboto', Arial, Geneva, sans-serif; }
 .font-arial { --font-family: 'Arial', sans-serif; }
 .font-geneva { --font-family: 'Geneva', sans-serif; }
+
+@media (max-width: 600px) {
+    #transactions-table {
+        font-size: 0.75rem;
+    }
+}


### PR DESCRIPTION
## Summary
- tweak `#transactions-table` base font size
- keep label column wide enough on small screens
- shrink table font size on narrow viewports

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685cf0857964832f9d516ba5a536f830