### PR TITLE
Improve transaction filtering UI

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -404,6 +404,22 @@ def list_transactions():
     if category:
         query = query.join(Category).filter(Category.name == category)
 
+    tx_type = request.args.get('type')
+    if tx_type:
+        query = query.filter(Transaction.tx_type == tx_type)
+
+    payment_method = request.args.get('payment_method')
+    if payment_method:
+        query = query.filter(Transaction.payment_method == payment_method)
+
+    label = request.args.get('label')
+    if label:
+        query = query.filter(Transaction.label.contains(label))
+
+    subcategory = request.args.get('subcategory')
+    if subcategory:
+        query = query.join(Subcategory).filter(Subcategory.name == subcategory)
+
     start_date = request.args.get('start_date')
     if start_date:
         try:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -74,9 +74,20 @@
                             <th>
                                 <input type="date" id="filter-start-date" />
                                 <input type="date" id="filter-end-date" />
+                                <select id="filter-period">
+                                    <option value="">(Période)</option>
+                                    <option value="current-week">Semaine en cours</option>
+                                    <option value="previous-week">Semaine précédente</option>
+                                    <option value="current-month">Mois en cours</option>
+                                    <option value="previous-month">Mois précédent</option>
+                                    <option value="ytd">Année en cours</option>
+                                    <option value="last-6-months">6 derniers mois</option>
+                                    <option value="previous-year">Année précédente</option>
+                                    <option value="all">Tout</option>
+                                </select>
                             </th>
-                            <th><input type="text" id="filter-type" placeholder="Type" /></th>
-                            <th><input type="text" id="filter-payment" placeholder="Moyen" /></th>
+                            <th><select id="filter-type"><option value="">(Tous)</option></select></th>
+                            <th><select id="filter-payment"><option value="">(Tous)</option></select></th>
                             <th><input type="text" id="filter-label" placeholder="Libellé" /></th>
                             <th>
                                 <input type="number" id="filter-min-amount" placeholder="Min" style="width:5em;" />
@@ -298,8 +309,14 @@
         async function fetchTransactions() {
             const params = new URLSearchParams();
             if (selectedAccountId) params.set('account_id', selectedAccountId);
-            const start = document.getElementById('filter-start-date').value;
-            const end = document.getElementById('filter-end-date').value;
+            let start = document.getElementById('filter-start-date').value;
+            let end = document.getElementById('filter-end-date').value;
+            const period = document.getElementById('filter-period').value;
+            if (period) {
+                const d = getPeriodDates(period);
+                start = d.start;
+                end = d.end;
+            }
             const txType = document.getElementById('filter-type').value.trim();
             const pay = document.getElementById('filter-payment').value.trim();
             const label = document.getElementById('filter-label').value.trim();
@@ -321,6 +338,28 @@
             if (!resp.ok) return;
             const data = await resp.json();
             displayAccountInfo();
+            const typeSel = document.getElementById('filter-type');
+            const paySel = document.getElementById('filter-payment');
+            const currentType = typeSel.value;
+            const currentPay = paySel.value;
+            const types = [...new Set(data.map(t => t.type).filter(v => v))];
+            const pays = [...new Set(data.map(t => t.payment_method).filter(v => v))];
+            typeSel.innerHTML = '<option value="">(Tous)</option>';
+            types.forEach(v => {
+                const opt = document.createElement('option');
+                opt.value = v;
+                opt.textContent = v;
+                typeSel.appendChild(opt);
+            });
+            if (currentType) typeSel.value = currentType;
+            paySel.innerHTML = '<option value="">(Tous)</option>';
+            pays.forEach(v => {
+                const opt = document.createElement('option');
+                opt.value = v;
+                opt.textContent = v;
+                paySel.appendChild(opt);
+            });
+            if (currentPay) paySel.value = currentPay;
             const tbody = document.querySelector('#transactions-table tbody');
             tbody.innerHTML = '';
             data.forEach(t => {
@@ -1077,7 +1116,8 @@
         });
 
         const filterInputs = [
-            'filter-start-date', 'filter-end-date', 'filter-type', 'filter-payment',
+            'filter-start-date', 'filter-end-date', 'filter-period',
+            'filter-type', 'filter-payment',
             'filter-label', 'filter-min-amount', 'filter-max-amount',
             'filter-category', 'filter-subcategory'
         ];


### PR DESCRIPTION
## Summary
- add quick period select and dropdowns for type/payment on transaction list
- populate lists from fetched data and apply quick filters client-side
- support filtering by type and payment info in backend

## Testing
- `python -m py_compile backend/app.py backend/models.py`

------
https://chatgpt.com/codex/tasks/task_e_685d213a4e10832f9daddbce806fecf1