### PR TITLE
Add favorite feature for transactions and categories

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -23,6 +23,7 @@ class Category(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String, unique=True, nullable=False)
     color = Column(String, default='')
+    favorite = Column(Boolean, default=False)
     transactions = relationship('Transaction', back_populates='category')
     rules = relationship('Rule', back_populates='category')
     subcategories = relationship('Subcategory', back_populates='category')
@@ -33,6 +34,7 @@ class Subcategory(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String, nullable=False)
     color = Column(String, default='')
+    favorite = Column(Boolean, default=False)
     category_id = Column(Integer, ForeignKey('categories.id'), nullable=False)
 
     category = relationship('Category', back_populates='subcategories')
@@ -58,6 +60,7 @@ class Transaction(Base):
     tx_type = Column(String)
     payment_method = Column(String)
     bank_account_id = Column(Integer, ForeignKey('bank_accounts.id'))
+    favorite = Column(Boolean, default=False)
     category_id = Column(Integer, ForeignKey('categories.id'))
     subcategory_id = Column(Integer, ForeignKey('subcategories.id'))
     reconciled = Column(Boolean, default=False)
@@ -100,11 +103,20 @@ def init_db():
             conn.execute(text('ALTER TABLE transactions ADD COLUMN to_analyze INTEGER DEFAULT 1'))
         if 'bank_account_id' not in cols:
             conn.execute(text('ALTER TABLE transactions ADD COLUMN bank_account_id INTEGER'))
+        if 'favorite' not in cols:
+            conn.execute(text('ALTER TABLE transactions ADD COLUMN favorite INTEGER DEFAULT 0'))
 
         info = conn.execute(text('PRAGMA table_info(categories)')).fetchall()
         cols = {row[1] for row in info}
         if 'color' not in cols:
             conn.execute(text('ALTER TABLE categories ADD COLUMN color TEXT'))
+        if 'favorite' not in cols:
+            conn.execute(text('ALTER TABLE categories ADD COLUMN favorite INTEGER DEFAULT 0'))
+
+        info = conn.execute(text('PRAGMA table_info(subcategories)')).fetchall()
+        cols = {row[1] for row in info}
+        if 'favorite' not in cols:
+            conn.execute(text('ALTER TABLE subcategories ADD COLUMN favorite INTEGER DEFAULT 0'))
 
         info = conn.execute(text('PRAGMA table_info(rules)')).fetchall()
         cols = {row[1] for row in info}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -59,6 +59,7 @@
                 <table id="transactions-table">
                     <thead>
                         <tr>
+                            <th>★</th>
                             <th>Date</th>
                             <th>Type</th>
                             <th>Moyen de paiement</th>
@@ -71,6 +72,7 @@
                             <th>A analyser</th>
                         </tr>
                         <tr id="filter-row">
+                            <th></th>
                             <th>
                                 <input type="date" id="filter-start-date" />
                                 <input type="date" id="filter-end-date" />
@@ -367,6 +369,17 @@
                 const type = t.type || '';
                 const pay = t.payment_method || '';
 
+                const favCell = document.createElement('td');
+                const favBtn = document.createElement('button');
+                favBtn.className = 'tx-fav-btn';
+                favBtn.textContent = t.favorite ? '★' : '☆';
+                favBtn.addEventListener('click', async () => {
+                    await fetch('/transactions/' + t.id, {method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({favorite: !t.favorite})});
+                    fetchTransactions();
+                });
+                favCell.appendChild(favBtn);
+                tr.appendChild(favCell);
+
                 const dateCell = document.createElement('td');
                 dateCell.textContent = formatDate(t.date);
                 tr.appendChild(dateCell);
@@ -543,6 +556,14 @@
                 li.appendChild(colorSpan);
                 li.appendChild(document.createTextNode(c.name));
 
+                const fav = document.createElement('button');
+                fav.textContent = c.favorite ? '★' : '☆';
+                fav.onclick = async () => {
+                    await fetch('/categories/' + c.id, { method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({ favorite: !c.favorite }) });
+                    fetchCategories();
+                    fetchSubcategories();
+                };
+
                 const edit = document.createElement('button');
                 edit.textContent = 'Éditer';
                 edit.onclick = () => {
@@ -558,7 +579,7 @@
                     fetchRules();
                     fetchSubcategories();
                 };
-                li.append(' ', edit, ' ', del);
+                li.append(' ', fav, ' ', edit, ' ', del);
                 list.appendChild(li);
 
                 const opt = document.createElement('option');
@@ -629,6 +650,13 @@
                 li.appendChild(colorSpan);
                 li.appendChild(document.createTextNode(s.name));
 
+                const fav = document.createElement('button');
+                fav.textContent = s.favorite ? '★' : '☆';
+                fav.onclick = async () => {
+                    await fetch('/subcategories/' + s.id, { method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({ favorite: !s.favorite }) });
+                    fetchSubcategories();
+                };
+
                 const edit = document.createElement('button');
                 edit.textContent = 'Éditer';
                 edit.onclick = () => {
@@ -643,7 +671,7 @@
                     await fetch('/subcategories/' + s.id, { method: 'DELETE' });
                     fetchSubcategories();
                 };
-                li.append(' ', edit, ' ', del);
+                li.append(' ', fav, ' ', edit, ' ', del);
                 list.appendChild(li);
 
                 const opt = document.createElement('option');


### PR DESCRIPTION
## Summary
- support a new `favorite` boolean column on Transaction, Category, and Subcategory
- handle database migration for the new column in `init_db`
- expose and update favorite status in API endpoints
- display star buttons in the frontend to toggle favorites

## Testing
- `python -m py_compile backend/models.py backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685d23b89718832f99d7c748345f9851