### PR TITLE
Improve transactions table responsiveness

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -21,37 +21,32 @@ body {
 table { border-collapse: collapse; width: 100%; }
 th, td { border: 1px solid var(--border-color); padding: 4px; }
 #transactions-table {
-    width: 90%;
     font-size: 0.85rem;
+    table-layout: auto;
 }
-#transactions-table th:nth-child(4),
-#transactions-table td:nth-child(4) {
+#transactions-table th,
+#transactions-table td {
+    white-space: nowrap;
+}
+#transactions-table th:nth-child(5),
+#transactions-table td:nth-child(5) {
     white-space: normal;
     word-break: break-word;
-    min-width: 150px;
-}
-#transactions-table th:nth-child(1),
-#transactions-table td:nth-child(1),
-#transactions-table th:nth-child(5),
-#transactions-table td:nth-child(5),
-#transactions-table th:nth-child(8),
-#transactions-table td:nth-child(8),
-#transactions-table th:nth-child(9),
-#transactions-table td:nth-child(9) {
-    min-width: 90px;
 }
 #transactions-table th:nth-child(1),
 #transactions-table td:nth-child(1) {
     text-align: right;
 }
-#transactions-table th:nth-child(5),
-#transactions-table td:nth-child(5) {
+#transactions-table th:nth-child(6),
+#transactions-table td:nth-child(6) {
     text-align: right;
 }
-#transactions-table th:nth-child(8),
-#transactions-table td:nth-child(8),
 #transactions-table th:nth-child(9),
-#transactions-table td:nth-child(9) {
+#transactions-table td:nth-child(9),
+#transactions-table th:nth-child(10),
+#transactions-table td:nth-child(10),
+#transactions-table th:nth-child(11),
+#transactions-table td:nth-child(11) {
     text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- refactor `#transactions-table` styles to remove fixed widths and use `table-layout: auto`
- keep label column wrapping and avoid wrapping the other columns

## Testing
- `python -m py_compile backend/app.py backend/models.py run.py`

------
https://chatgpt.com/codex/tasks/task_e_685d3ff4fd64832fa33bc04bbbcc18d4