### PR TITLE
Improve hide amounts option layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -189,7 +189,9 @@
                     <option value="arial">Arial</option>
                     <option value="geneva">Geneva</option>
                 </select>
-                <label><input type="checkbox" id="hide-amounts"> Masquer montants</label>
+                <div>
+                    <label><input type="checkbox" id="hide-amounts"> Masquer montants</label>
+                </div>
 
                 <h2>RESET</h2>
                 <button id="reset-transactions">Effacer les transactions</button>


### PR DESCRIPTION
## Summary
- visually separate the "Masquer montants" option from the font selection by placing it inside its own `<div>` container in `index.html`

## Testing
- `python -m py_compile backend/app.py backend/models.py run.py`

------
https://chatgpt.com/codex/tasks/task_e_685d489965d4832fa053bc64d2fe5e10