### PR TITLE
Improve transaction table layout

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -22,31 +22,62 @@ table { border-collapse: collapse; width: 100%; }
 th, td { border: 1px solid var(--border-color); padding: 4px; }
 #transactions-table {
     font-size: 0.85rem;
-    table-layout: auto;
+    width: 95%;
+    table-layout: fixed;
 }
 #transactions-table th,
 #transactions-table td {
     white-space: nowrap;
 }
+#transactions-table th:nth-child(1),
+#transactions-table td:nth-child(1) {
+    width: 2em;
+    text-align: right;
+}
+#transactions-table th:nth-child(2),
+#transactions-table td:nth-child(2) {
+    width: 8em;
+}
+#transactions-table th:nth-child(3),
+#transactions-table td:nth-child(3) {
+    width: 6em;
+}
+#transactions-table th:nth-child(4),
+#transactions-table td:nth-child(4) {
+    width: 10em;
+}
 #transactions-table th:nth-child(5),
 #transactions-table td:nth-child(5) {
+    width: auto;
     white-space: normal;
     word-break: break-word;
 }
-#transactions-table th:nth-child(1),
-#transactions-table td:nth-child(1) {
-    text-align: right;
-}
 #transactions-table th:nth-child(6),
 #transactions-table td:nth-child(6) {
+    width: 6em;
     text-align: right;
 }
+#transactions-table th:nth-child(7),
+#transactions-table td:nth-child(7) {
+    width: 8em;
+}
+#transactions-table th:nth-child(8),
+#transactions-table td:nth-child(8) {
+    width: 8em;
+}
 #transactions-table th:nth-child(9),
-#transactions-table td:nth-child(9),
+#transactions-table td:nth-child(9) {
+    width: 5em;
+    text-align: center;
+}
 #transactions-table th:nth-child(10),
-#transactions-table td:nth-child(10),
+#transactions-table td:nth-child(10) {
+    width: 5em;
+    text-align: center;
+}
 #transactions-table th:nth-child(11),
 #transactions-table td:nth-child(11) {
+    width: 6em;
     text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- set `#transactions-table` width to `95%` and use fixed layout
- add explicit widths to the transaction table columns so that the label column takes remaining space

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d49ad47d0832fb953a8f3e26e021a