### PR TITLE
Fix filter dropdown width

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -29,6 +29,16 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
 #transactions-table td {
     white-space: nowrap;
 }
+
+/* Keep filter dropdowns within their cells when collapsed */
+#filter-row select {
+    max-width: 100%;
+}
+#filter-row th,
+#filter-row td {
+    position: relative;
+    overflow: visible;
+}
 #transactions-table th:nth-child(1),
 #transactions-table td:nth-child(1) {
     width: 2em;


### PR DESCRIPTION
## Summary
- prevent collapsed filter selects from exceeding their cell width
- allow dropdowns to overlap adjacent columns as needed

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685d4c709980832f873443f5a89aff96