### PR TITLE
Add favorite button color styles

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -161,6 +161,13 @@ input[type="button"] {
 
 }
 
+.tx-fav-btn {
+    color: var(--interactive-color);
+}
+.tx-fav-btn.selected {
+    color: #fc9107;
+}
+
 /* Ensure menu buttons have no visible border */
 #navbar .submenu button,
 .menu-header {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -391,7 +391,7 @@
 
                 const favCell = document.createElement('td');
                 const favBtn = document.createElement('button');
-                favBtn.className = 'tx-fav-btn';
+                favBtn.className = 'tx-fav-btn' + (t.favorite ? ' selected' : '');
                 favBtn.textContent = t.favorite ? '★' : '☆';
                 favBtn.addEventListener('click', async () => {
                     await fetch('/transactions/' + t.id, {method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({favorite: !t.favorite})});


### PR DESCRIPTION
## Summary
- style favorite buttons with blue/off color and orange for selected
- color fav buttons according to favorite flag

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685d4deed76c832fafde60fa384367f5