### PR TITLE
Update navigation structure

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -142,6 +142,10 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
     padding: 4px 8px;
     border: none;
 }
+#navbar button[data-target] {
+    padding: 4px 8px;
+    border: none;
+}
 #content { flex-grow: 1; padding: 60px 10px 0 10px; }
 
 a {
@@ -169,7 +173,7 @@ input[type="button"] {
 }
 
 /* Ensure menu buttons have no visible border */
-#navbar .submenu button,
+#navbar button[data-target],
 .menu-header {
     border: none;
 }
@@ -181,7 +185,7 @@ input[type="radio"] {
 
 }
 
-#navbar .submenu button.selected,
+#navbar button[data-target].selected,
 .menu-header.selected,
 tr.selected {
     color: #fc9107;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,10 +24,10 @@
                         <li><button data-target="transactions-section">Transactions</button></li>
                     </ul>
                 </li>
+                <li><button data-target="dashboard-section">Tableau de bord</button></li>
                 <li>
                     <div class="menu-header">Analyses</div>
                     <ul class="submenu">
-                        <li><button data-target="dashboard-section">Dashboard</button></li>
                         <li><button data-target="stats-section">Statistiques</button></li>
                         <li><button data-target="projection-section">Projections</button></li>
                     </ul>
@@ -1145,7 +1145,7 @@
         });
 
         const sectionIds = ['transactions-section', 'dashboard-section', 'stats-section', 'projection-section', 'settings-section'];
-        const sidebarButtons = document.querySelectorAll('#navbar .submenu button');
+        const sidebarButtons = document.querySelectorAll('#navbar button[data-target]');
         sidebarButtons.forEach(btn => {
             btn.addEventListener('click', () => {
                 const target = btn.dataset.target;


### PR DESCRIPTION
## Summary
- make the dashboard link a standalone nav item
- remove dashboard from the Analyses submenu
- hook up navigation events for all nav buttons
- style standalone nav buttons like submenu items

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d4ed0f83c832f8787630f2fcbcba5