### PR TITLE
Move account dropdown next to transactions heading

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -39,6 +39,16 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
     position: relative;
     overflow: visible;
 }
+#transactions-section .transactions-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+#account-controls {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
 #transactions-table th:nth-child(1),
 #transactions-table td:nth-child(1) {
     width: 2em;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -53,15 +53,16 @@
                     <button type="submit">Importer CSV</button>
                 </form>
 
-                <div id="account-controls">
-                    <label for="account-select">Compte :</label>
-                    <select id="account-select">
-                        <option value="">(Tous)</option>
-                    </select>
-                    <span id="account-info"></span>
+                <div class="transactions-header">
+                    <h2>Transactions</h2>
+                    <div id="account-controls">
+                        <label for="account-select">Compte :</label>
+                        <select id="account-select">
+                            <option value="">(Tous)</option>
+                        </select>
+                        <span id="account-info"></span>
+                    </div>
                 </div>
-
-                <h2>Transactions</h2>
                 <table id="transactions-table">
                     <thead>
                         <tr>


### PR DESCRIPTION
## Summary
- group the Transactions heading and account dropdown in a flex container
- style the header so the dropdown sits inline with the heading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d513bfb4c832f95df6b14c6916dd2