### PR TITLE
Adjust transaction table column styles

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -78,31 +78,37 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
 }
 #transactions-table th:nth-child(6),
 #transactions-table td:nth-child(6) {
-    width: 6em;
     text-align: right;
+    padding-left: 5px;
+    padding-right: 5px;
 }
 #transactions-table th:nth-child(7),
 #transactions-table td:nth-child(7) {
-    width: 8em;
+    padding-left: 5px;
+    padding-right: 5px;
 }
 #transactions-table th:nth-child(8),
 #transactions-table td:nth-child(8) {
-    width: 8em;
+    padding-left: 5px;
+    padding-right: 5px;
 }
 #transactions-table th:nth-child(9),
 #transactions-table td:nth-child(9) {
-    width: 5em;
     text-align: center;
+    padding-left: 5px;
+    padding-right: 5px;
 }
 #transactions-table th:nth-child(10),
 #transactions-table td:nth-child(10) {
-    width: 5em;
     text-align: center;
+    padding-left: 5px;
+    padding-right: 5px;
 }
 #transactions-table th:nth-child(11),
 #transactions-table td:nth-child(11) {
-    width: 6em;
     text-align: center;
+    padding-left: 5px;
+    padding-right: 5px;
 }
 
 #catsubs-container {


### PR DESCRIPTION
## Summary
- remove fixed widths from transaction table columns 6-11
- add left/right padding for these columns
- keep table-level `table-layout: fixed`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685d5f0f258c832fb44c88793f24b4c0