### PR TITLE
Handle trailing minus amounts in CSV parser

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -157,8 +157,20 @@ def parse_csv(content):
 
         try:
             cleaned = amount_str.replace('\xa0', '').replace(' ', '')
+
+            # Detect negative formats like "123,45-" or "(123,45)"
+            negative = False
+            if cleaned.endswith('-'):
+                negative = True
+                cleaned = cleaned[:-1]
+            elif cleaned.startswith('(') and cleaned.endswith(')'):
+                negative = True
+                cleaned = cleaned[1:-1]
+
             cleaned = cleaned.replace(',', '.')
             amount = float(cleaned)
+            if negative:
+                amount = -amount
         except ValueError:
             errors.append(f'Ligne {line_no}: montant invalide')
             continue

--- a/tests/test_parse_csv.py
+++ b/tests/test_parse_csv.py
@@ -44,3 +44,16 @@ def test_parse_csv_missing_fields():
     assert duplicates == []
     assert errors
     assert "colonnes manquantes" in errors[0]
+
+
+def test_parse_csv_trailing_minus():
+    csv_data = """Compte courant 12345678 2021-01-01
+2021-01-02;Debit;CB;Achat;123,45-
+"""
+
+    transactions, duplicates, errors, info = parse_csv(csv_data)
+
+    assert not errors
+    assert duplicates == []
+    assert len(transactions) == 1
+    assert transactions[0]["amount"] == -123.45


### PR DESCRIPTION
## Summary
- improve `parse_csv` to detect trailing minus and parenthesis formats
- test number parsing with a trailing `-`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685d6064af8c832fa97201c335343613