### PR TITLE
Add bank accounts endpoint and frontend integration

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -77,6 +77,24 @@ def me():
     return jsonify({'error': 'Unauthorized'}), 401
 
 
+@app.route('/accounts')
+@login_required
+def accounts():
+    """Return all bank accounts."""
+    session = SessionLocal()
+    data = [
+        {
+            'id': a.id,
+            'account_type': a.account_type,
+            'number': a.number,
+            'export_date': a.export_date.isoformat() if a.export_date else None,
+        }
+        for a in session.query(BankAccount).all()
+    ]
+    session.close()
+    return jsonify(data)
+
+
 def parse_csv(content):
     """Parse CSV content and return valid transactions, account info and errors.
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -498,6 +498,10 @@
                 body: JSON.stringify({ username, password })
             });
             if (resp.ok) {
+                const accResp = await fetch('/accounts');
+                if (accResp.ok) {
+                    accountsData = await accResp.json();
+                }
                 document.getElementById('login-form').style.display = 'none';
                 document.getElementById('app').style.display = 'block';
                 updateAccountDropdown();

--- a/tests/test_accounts_endpoint.py
+++ b/tests/test_accounts_endpoint.py
@@ -1,0 +1,38 @@
+import datetime
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+from backend import app as app_module
+
+@pytest.fixture
+def client():
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    models.init_db()
+    session = models.SessionLocal()
+    acc = models.BankAccount(account_type='Compte', number='123', export_date=datetime.date(2021, 1, 1))
+    session.add(acc)
+    session.commit()
+    session.close()
+    with app_module.app.test_client() as client:
+        yield client
+
+
+def test_accounts_requires_login(client):
+    resp = client.get('/accounts')
+    assert resp.status_code == 401
+
+
+def test_accounts_returns_accounts(client):
+    login = client.post('/login', json={'username': 'admin', 'password': 'admin'})
+    assert login.status_code == 200
+    resp = client.get('/accounts')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]['number'] == '123'


### PR DESCRIPTION
## Summary
- expose new `/accounts` route for listing all `BankAccount`s
- fetch accounts on login and populate the dropdown
- add tests for `/accounts` endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for flask and sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_685d64221b70832f9da403b5d8fff98a