### PR TITLE
Handle empty category stats

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -122,6 +122,12 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
     gap: 20px;
 }
 
+#category-no-data {
+    text-align: center;
+    font-style: italic;
+    margin-top: 10px;
+}
+
 #categories-list li,
 #subcategories-list li,
 #rules-list li {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -130,6 +130,7 @@
                     <canvas id="incomeChart" width="300" height="300"></canvas>
                     <canvas id="expenseChart" width="300" height="300"></canvas>
                 </div>
+                <div id="category-no-data" style="display:none;">No data</div>
                 <canvas id="sankeyChart" width="600" height="300"></canvas>
             </section>
 
@@ -885,6 +886,17 @@
                     expColors.push(d.color || 'gray');
                 }
             });
+            const chartsDiv = document.getElementById('category-charts');
+            const emptyNotice = document.getElementById('category-no-data');
+            if (incData.length === 0 && expData.length === 0) {
+                if (incomeChart) { incomeChart.destroy(); incomeChart = null; }
+                if (expenseChart) { expenseChart.destroy(); expenseChart = null; }
+                chartsDiv.style.display = 'none';
+                emptyNotice.style.display = 'block';
+                return;
+            }
+            chartsDiv.style.display = 'flex';
+            emptyNotice.style.display = 'none';
             const ictx = document.getElementById('incomeChart').getContext('2d');
             if (incomeChart) incomeChart.destroy();
             const hide = localStorage.getItem('hideAmounts') === 'true';


### PR DESCRIPTION
## Summary
- show a *No data* notice if category charts have no data
- style the notice in CSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy and flask)*

------
https://chatgpt.com/codex/tasks/task_e_685d6acc0060832f9c3af63645e91578