### PR TITLE
Fix display of projection amounts

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1010,7 +1010,7 @@
                 const input = document.createElement('input');
                 input.type = 'number';
                 input.step = '0.01';
-                input.value = d.amount;
+                input.value = Number(d.amount).toFixed(2);
                 input.className = 'amount-input';
                 amountCell.appendChild(input);
                 tr.appendChild(amountCell);


### PR DESCRIPTION
## Summary
- format projection input values with two decimal places for consistent display

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for Flask and SQLAlchemy)*

------
https://chatgpt.com/codex/tasks/task_e_685d7010eea4832faf6457d601a7f6a5