### PR TITLE
Add formatted callbacks for charts

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -252,9 +252,25 @@
         }
 
         function getChartOptions(hide, withScale = true) {
-            const opts = { plugins: { tooltip: { enabled: !hide } } };
+            const opts = {
+                plugins: {
+                    tooltip: {
+                        enabled: !hide,
+                        callbacks: {
+                            label: ctx => formatAmount(ctx.parsed.y ?? ctx.parsed)
+                        }
+                    }
+                }
+            };
             if (withScale) {
-                opts.scales = { y: { ticks: { display: !hide } } };
+                opts.scales = {
+                    y: {
+                        ticks: {
+                            display: !hide,
+                            callback: val => formatAmount(val)
+                        }
+                    }
+                };
             }
             return opts;
         }


### PR DESCRIPTION
## Summary
- show formatted amounts on chart axes and tooltips

## Testing
- `pytest -q` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685d70dcee04832fb44aa09726f1e79b