### PR TITLE
Fix CSV re-import handling and add regression test

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -262,7 +262,8 @@ def import_csv():
     except Exception as e:
         return jsonify({'error': str(e)}), 400
 
-    transactions, csv_duplicates, errors, account_info = parse_csv(content)
+    transactions, csv_duplicates, csv_errors, account_info = parse_csv(content)
+    errors = list(csv_errors)
 
     session = SessionLocal()
     imported = 0

--- a/tests/test_import_endpoint.py
+++ b/tests/test_import_endpoint.py
@@ -1,0 +1,45 @@
+import io
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+from backend import app as app_module
+
+@pytest.fixture
+def client():
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    models.init_db()
+    with app_module.app.test_client() as client:
+        yield client
+
+def login(client):
+    resp = client.post('/login', json={'username': 'admin', 'password': 'admin'})
+    assert resp.status_code == 200
+
+def import_file(client, csv):
+    data = {'file': (io.BytesIO(csv.encode('utf-8')), 'test.csv')}
+    return client.post('/import', data=data, content_type='multipart/form-data')
+
+
+def test_reimport_returns_duplicates(client):
+    login(client)
+    csv = """Compte courant 12345678 2021-01-01
+2021-01-02;Debit;CB;Achat;-12,34
+2021-01-03;Credit;VIR;Salaire;1000,00
+"""
+    first = import_file(client, csv)
+    assert first.status_code == 200
+    data1 = first.get_json()
+    assert data1.get('imported') == 2
+    assert 'duplicates' not in data1
+
+    second = import_file(client, csv)
+    assert second.status_code == 200
+    data2 = second.get_json()
+    assert not data2.get('errors')
+    assert 'duplicates' in data2
+    assert len(data2['duplicates']) == 2


### PR DESCRIPTION
## Summary
- fix `import_csv` to keep CSV parsing errors separate
- add regression test for re-importing CSV files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685d87a40104832f856d87825f261c18