### PR TITLE
Dashboard alerts and summaries

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1006,8 +1006,28 @@
             const resp = await fetch('/dashboard');
             if (!resp.ok) return;
             const data = await resp.json();
-            document.getElementById('dashboard-content').textContent =
-                `Favoris: ${data.favorite_count} | Total 30j: ${formatAmount(data.recent_total)} | Solde: ${formatAmount(data.balance_total)}`;
+            const container = document.getElementById('dashboard-content');
+            container.innerHTML = `<p>Favoris: ${data.favorite_count} | Total 30j: ${formatAmount(data.recent_total)} | Solde: ${formatAmount(data.balance_total)}</p>`;
+            if (data.alerts && data.alerts.length) {
+                const ul = document.createElement('ul');
+                data.alerts.forEach(a => {
+                    const li = document.createElement('li');
+                    li.textContent = a;
+                    ul.appendChild(li);
+                });
+                container.appendChild(ul);
+            }
+            if (data.favorite_summaries && data.favorite_summaries.length) {
+                const table = document.createElement('table');
+                table.innerHTML = '<thead><tr><th>Favori</th><th>Mois en cours</th><th>Moy. 6 mois</th></tr></thead><tbody></tbody>';
+                const tbody = table.querySelector('tbody');
+                data.favorite_summaries.forEach(f => {
+                    const tr = document.createElement('tr');
+                    tr.innerHTML = `<td>${f.name}</td><td>${formatAmount(f.current_total)}</td><td>${formatAmount(f.six_month_avg)}</td>`;
+                    tbody.appendChild(tr);
+                });
+                container.appendChild(table);
+            }
             const ctx = document.getElementById('dashboardChart').getContext('2d');
             if (dashboardChart) dashboardChart.destroy();
             const hide = localStorage.getItem('hideAmounts') === 'true';

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,59 @@
+import datetime
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+from backend import app as app_module
+
+class FixedDate(datetime.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2021, 5, 15)
+
+@pytest.fixture
+def client(monkeypatch):
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    models.init_db()
+    session = models.SessionLocal()
+    cat = models.Category(name='Food', favorite=True)
+    session.add(cat)
+    fil = models.FavoriteFilter(pattern='Shop')
+    session.add(fil)
+    session.add_all([
+        models.Transaction(date=datetime.date(2021,2,5), label='inc1', amount=1000),
+        models.Transaction(date=datetime.date(2021,3,5), label='inc2', amount=1200),
+        models.Transaction(date=datetime.date(2021,4,5), label='inc3', amount=800),
+        models.Transaction(date=datetime.date(2021,4,10), label='Food Apr', amount=-60, category=cat),
+        models.Transaction(date=datetime.date(2021,5,10), label='Groceries', amount=-50, category=cat),
+        models.Transaction(date=datetime.date(2021,5,12), label='Huge expense', amount=-1200, category=cat),
+        models.Transaction(date=datetime.date(2021,5,13), label='Shop now', amount=-70, category=cat),
+        models.Transaction(date=datetime.date(2021,3,6), label='Shop old', amount=-30, category=cat),
+        models.Transaction(date=datetime.date(2021,2,6), label='Shop older', amount=-40, category=cat),
+        models.Transaction(date=datetime.date(2021,4,6), label='Shop old2', amount=-50, category=cat),
+    ])
+    session.commit()
+    session.close()
+    with app_module.app.test_client() as client:
+        yield client
+
+def login(client):
+    resp = client.post('/login', json={'username': 'admin', 'password': 'admin'})
+    assert resp.status_code == 200
+
+
+def test_dashboard_alerts_and_summaries(client):
+    login(client)
+    resp = client.get('/dashboard')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert any('Huge expense' in a for a in data['alerts'])
+    favs = {f['name']: f for f in data['favorite_summaries']}
+    assert 'Shop' in favs
+    assert favs['Shop']['current_total'] == -70
+    assert 'Food' in favs
+

--- a/tests/test_dashboard_helper.py
+++ b/tests/test_dashboard_helper.py
@@ -1,0 +1,40 @@
+import datetime
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+from backend import app as app_module
+
+class FixedDate(datetime.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2021, 5, 15)
+
+
+def setup_db(monkeypatch):
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    models.init_db()
+    return models.SessionLocal()
+
+
+def test_compute_dashboard_averages(monkeypatch):
+    session = setup_db(monkeypatch)
+    cat = models.Category(name='Food')
+    session.add(cat)
+    session.add_all([
+        models.Transaction(date=datetime.date(2021,2,5), label='inc1', amount=1000),
+        models.Transaction(date=datetime.date(2021,3,5), label='inc2', amount=1200),
+        models.Transaction(date=datetime.date(2021,4,5), label='inc3', amount=800),
+        models.Transaction(date=datetime.date(2021,4,10), label='t1', amount=-60, category=cat),
+        models.Transaction(date=datetime.date(2021,5,10), label='t2', amount=-40, category=cat),
+    ])
+    session.commit()
+    cat_avgs, income_avg = app_module.compute_dashboard_averages(session)
+    assert round(cat_avgs[cat.id], 2) == 50
+    assert income_avg == pytest.approx(1000)
+    session.close()


### PR DESCRIPTION
## Summary
- compute category and income averages
- raise dashboard alerts for unusual transactions
- summarise favourite filters, categories and subcategories
- display alerts and summaries on dashboard
- add unit tests for dashboard helper and endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685d93a4671c832f95033091af416283