### PR TITLE
Add development setup docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: package
+.PHONY: package test
 
 package:
-        pyinstaller --onefile --add-data "frontend:frontend" run.py
+	pyinstaller --onefile --add-data "frontend:frontend" run.py
+
+test:
+	pip install -r requirements-dev.txt
+	pytest

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Avant le premier démarrage, installez les dépendances du projet&nbsp;:
 
 ```bash
 pip install -r requirements.txt
+pip install -r requirements-dev.txt
 python run.py
 ```
 
@@ -26,6 +27,16 @@ Par défaut, l'application s'ouvrira automatiquement dans votre navigateur à l'
 Si ce n'est pas le cas, ouvrez manuellement cette URL.
 Le serveur Flask écoute sur l'adresse `0.0.0.0`, ce qui permet d'exposer
 l'application sur le réseau local.
+
+## Environnement de développement
+
+Les dépendances principales (**Flask**, **SQLAlchemy**, **Flask-Login**) ainsi que
+**pytest** pour les tests sont listées dans `requirements-dev.txt`. Installez-les
+pour disposer d'un environnement complet :
+
+```bash
+pip install -r requirements-dev.txt
+```
 
 ## Base de données
 
@@ -43,10 +54,10 @@ supprimé en cas de réinitialisation souhaitée.
 
 ## Tests
 
-Avant de lancer la suite de tests, installez les dépendances du projet :
+Avant de lancer la suite de tests, installez les dépendances de développement :
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements-dev.txt
 ```
 
 Les tests s'appuient sur **pytest**. Une fois les dépendances en place, exécutez :

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 Flask
 SQLAlchemy
 Flask-Login
-pytest


### PR DESCRIPTION
## Summary
- document dev dependencies and how to install them
- split dev requirements into `requirements-dev.txt`
- run `pip install` and `pytest` via `make test`

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement Flask)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685d952d8050832f81547acbbc9f8a6b