### PR TITLE
Add default categories dataset

### DIFF
--- a/backend/categories.json
+++ b/backend/categories.json
@@ -1,0 +1,140 @@
+{
+  "Auto et Transports": [
+    "Amendes",
+    "Location de voiture",
+    "Lavage",
+    "Carburant",
+    "Assurance",
+    "Parking",
+    "Billets d'avion",
+    "Transports publics",
+    "Réparations",
+    "Taxis, VTC et Covoiturages",
+    "Péages",
+    "Billets de train"
+  ],
+  "Factures et Services": [
+    "Autres abonnements",
+    "Électricité",
+    "Chauffage",
+    "Internet",
+    "Téléphone portable",
+    "Déchets et Recyclage",
+    "Eau"
+  ],
+  "Dépenses professionnelles": [
+    "Comptabilité",
+    "Publicité",
+    "Voyages d'affaires",
+    "Conseil financier",
+    "Freelancing",
+    "Assistance juridique",
+    "Marketing",
+    "Fournitures de bureau",
+    "Services en ligne",
+    "Impressions",
+    "Services professionnels",
+    "Salaire",
+    "Frais d'envois"
+  ],
+  "Espèces et Chèques": [
+    "Dépôts en espèces",
+    "Dépôts de chèques",
+    "Retraits"
+  ],
+  "Frais": [
+    "Frais bancaires",
+    "Frais de retard",
+    "Frais de service"
+  ],
+  "Alimentation et Boissons": [
+    "Bars",
+    "Cafés",
+    "Restaurants",
+    "FastFood",
+    "Courses"
+  ],
+  "Santé": [
+    "Dentiste",
+    "Médecin",
+    "Assurance maladie",
+    "Matériel médical",
+    "Médicaments",
+    "Opticien"
+  ],
+  "Revenus": [
+    "Bonus",
+    "Cadeaux",
+    "Investissements",
+    "Revenus locatifs",
+    "Salaire"
+  ],
+  "Investissements": [
+    "Obligations",
+    "Cryptos",
+    "Immobilier",
+    "Retraite",
+    "Epargne de sécurité",
+    "Services payants",
+    "Actions"
+  ],
+  "Loisirs et Divertissements": [
+    "Art et Musées",
+    "Cadeaux",
+    "Chats / Animaux",
+    "Hobbies",
+    "Hotel / hébergement",
+    "Informatique",
+    "Jardinage",
+    "LIONS CLUB",
+    "Modelisme",
+    "Cinéma et Théâtre",
+    "Plongée",
+    "Sports",
+    "Abonnements",
+    "Vacances"
+  ],
+  "Remboursement emprunt": [
+    "Maison",
+    "Voiture",
+    "consommation"
+  ],
+  "Besoins essentiels": [
+    "Bricollage",
+    "Modifier",
+    "Garde d'enfants",
+    "Vêtements",
+    "Éducation",
+    "Soins personnels",
+    "Cadeaux",
+    "Animaux de compagnie",
+    "Loyer",
+    "Logement étudiant",
+    "Fournitures ménagères",
+    "Tabac",
+    "Frais de scolarité"
+  ],
+  "Remboursements": [
+    "Paiements d'assurances",
+    "Retours produits",
+    "Remboursements d'impôts",
+    "Réclamations et Garanties"
+  ],
+  "Impôts": [
+    "Impôts sur les sociétés",
+    "Impôts sur les plus-values",
+    "Impôts sur le revenu",
+    "Impôts fonciers",
+    "Cotisations sociales",
+    "TVA"
+  ],
+  "Virements": [
+    "Paiement des factures",
+    "Transferts externes",
+    "EG",
+    "Dons",
+    "Transferts internes",
+    "Transferts internationaux"
+  ],
+  "Autre": []
+}

--- a/backend/models.py
+++ b/backend/models.py
@@ -2,6 +2,8 @@ from sqlalchemy import create_engine, Column, Integer, String, Float, Date, Bool
 from sqlalchemy.orm import declarative_base, relationship, sessionmaker
 from flask_login import UserMixin
 from werkzeug.security import generate_password_hash
+import os
+import json
 
 engine = create_engine('sqlite:///tresoperso.db')
 SessionLocal = sessionmaker(bind=engine)
@@ -150,4 +152,20 @@ def init_db():
         user = User(username='admin', password=generate_password_hash('admin'))
         session.add(user)
         session.commit()
+
+    # Populate default categories and subcategories if provided
+    if not session.query(Category).first():
+        path = os.path.join(os.path.dirname(__file__), 'categories.json')
+        if os.path.exists(path):
+            with open(path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            for cat_name, subcats in data.items():
+                cat = Category(name=cat_name)
+                session.add(cat)
+                session.flush()
+                for sub_name in subcats:
+                    sub = Subcategory(name=sub_name, category_id=cat.id)
+                    session.add(sub)
+            session.commit()
+
     session.close()


### PR DESCRIPTION
## Summary
- seed categories from `backend/categories.json`
- add the JSON file listing default categories and subcategories

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e284ca560832f8284b8c52bbda71c