### PR TITLE
Sync categories from JSON on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Le backend repose sur **SQLAlchemy** avec une base SQLite créée dans le
 fichier `tresoperso.db`. Lors du premier démarrage, les tables ainsi qu'un
 compte administrateur `admin` (mot de passe `admin`) sont générés
 automatiquement.
+Les catégories et sous-catégories sont également synchronisées depuis le fichier
+`backend/categories.json` à chaque démarrage.
 
 ```bash
 python run.py

--- a/backend/models.py
+++ b/backend/models.py
@@ -153,19 +153,25 @@ def init_db():
         session.add(user)
         session.commit()
 
-    # Populate default categories and subcategories if provided
-    if not session.query(Category).first():
-        path = os.path.join(os.path.dirname(__file__), 'categories.json')
-        if os.path.exists(path):
-            with open(path, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-            for cat_name, subcats in data.items():
+    # Synchronize categories and subcategories from categories.json
+    path = os.path.join(os.path.dirname(__file__), 'categories.json')
+    if os.path.exists(path):
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        for cat_name, subcats in data.items():
+            cat = session.query(Category).filter_by(name=cat_name).first()
+            if not cat:
                 cat = Category(name=cat_name)
                 session.add(cat)
-                session.flush()
-                for sub_name in subcats:
-                    sub = Subcategory(name=sub_name, category_id=cat.id)
-                    session.add(sub)
-            session.commit()
+                session.flush()  # ensure cat.id is available
+            for sub_name in subcats:
+                exists = (
+                    session.query(Subcategory)
+                    .filter_by(name=sub_name, category_id=cat.id)
+                    .first()
+                )
+                if not exists:
+                    session.add(Subcategory(name=sub_name, category_id=cat.id))
+        session.commit()
 
     session.close()

--- a/tests/test_init_db_categories.py
+++ b/tests/test_init_db_categories.py
@@ -1,0 +1,27 @@
+import json
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from backend import models
+
+
+def test_init_db_syncs_categories(tmp_path, monkeypatch):
+    data = {
+        "CatA": ["Sub1", "Sub2"],
+        "CatB": []
+    }
+    (tmp_path / "categories.json").write_text(json.dumps(data), encoding="utf-8")
+
+    # configure in-memory DB
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+
+    # patch path so init_db reads from our temp categories.json
+    monkeypatch.setattr(models, "__file__", str(tmp_path / "models.py"))
+
+    models.init_db()
+    session = models.SessionLocal()
+    cats = {c.name: [s.name for s in c.subcategories] for c in session.query(models.Category).all()}
+    session.close()
+    assert cats == {"CatA": ["Sub1", "Sub2"], "CatB": []}


### PR DESCRIPTION
## Summary
- always populate DB categories from `categories.json`
- test `init_db` category synchronization
- mention automatic category sync in the README

## Testing
- `pytest -q tests/test_init_db_categories.py` *(fails: ModuleNotFoundError for `sqlalchemy`)*

------
https://chatgpt.com/codex/tasks/task_e_685e49bef1d0832f81f25b318dab6e01