### PR TITLE
Update category color propagation

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1106,6 +1106,8 @@ def categories(category_id=None):
             category.name = name
         if color is not None:
             category.color = color
+            for sub in category.subcategories:
+                sub.color = color
         session.commit()
 
         # update categories.json if name has changed

--- a/tests/test_categories_endpoint.py
+++ b/tests/test_categories_endpoint.py
@@ -1,0 +1,44 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+from backend import app as app_module
+
+
+@pytest.fixture
+def client():
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    models.init_db()
+    session = models.SessionLocal()
+    cat = models.Category(name='Food', color='red')
+    session.add(cat)
+    sub = models.Subcategory(name='Meal', category=cat, color=cat.color)
+    session.add(sub)
+    session.commit()
+    cat_id = cat.id
+    sub_id = sub.id
+    session.close()
+    with app_module.app.test_client() as client:
+        client.cat_id = cat_id
+        client.sub_id = sub_id
+        yield client
+
+
+def login(client):
+    resp = client.post('/login', json={'username': 'admin', 'password': 'admin'})
+    assert resp.status_code == 200
+
+
+def test_put_category_color_updates_subs(client):
+    login(client)
+    new_color = '#00ff00'
+    resp = client.put(f'/categories/{client.cat_id}', json={'color': new_color})
+    assert resp.status_code == 200
+    session = models.SessionLocal()
+    sub = session.query(models.Subcategory).get(client.sub_id)
+    session.close()
+    assert sub.color == new_color


### PR DESCRIPTION
## Summary
- propagate category color changes to subcategories
- add test for color update on subcategories

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685e6094cf78832fb6d648995a75ef06