### PR TITLE
Add name field to bank accounts with CRUD support

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -46,6 +46,7 @@ class BankAccount(Base):
     __tablename__ = 'bank_accounts'
 
     id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False, default='')
     account_type = Column(String)
     number = Column(String)
     export_date = Column(Date)
@@ -141,6 +142,8 @@ def init_db():
 
         info = conn.execute(text('PRAGMA table_info(bank_accounts)')).fetchall()
         cols = {row[1] for row in info}
+        if 'name' not in cols:
+            conn.execute(text("ALTER TABLE bank_accounts ADD COLUMN name TEXT DEFAULT '' NOT NULL"))
         if 'initial_balance' not in cols:
             conn.execute(text('ALTER TABLE bank_accounts ADD COLUMN initial_balance REAL DEFAULT 0'))
         if 'balance_date' not in cols:

--- a/tests/test_accounts_crud.py
+++ b/tests/test_accounts_crud.py
@@ -1,0 +1,47 @@
+import datetime
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+from backend import app as app_module
+
+@pytest.fixture
+def client():
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    models.init_db()
+    with app_module.app.test_client() as client:
+        yield client
+
+def login(client):
+    resp = client.post('/login', json={'username': 'admin', 'password': 'admin'})
+    assert resp.status_code == 200
+
+
+def test_create_update_delete_account(client):
+    login(client)
+    # create
+    resp = client.post('/accounts', json={'name': 'Main', 'account_type': 'Compte', 'number': '1'})
+    assert resp.status_code == 201
+    data = resp.get_json()
+    acc_id = data['id']
+    assert data['name'] == 'Main'
+
+    # update
+    resp = client.put(f'/accounts/{acc_id}', json={'name': 'Updated', 'number': '2'})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['name'] == 'Updated'
+    assert data['number'] == '2'
+
+    # delete
+    resp = client.delete(f'/accounts/{acc_id}')
+    assert resp.status_code == 204
+    session = models.SessionLocal()
+    acc = session.query(models.BankAccount).get(acc_id)
+    session.close()
+    assert acc is None
+


### PR DESCRIPTION
## Summary
- expand `BankAccount` model with a `name` column
- upgrade `init_db` to add the column when missing
- enhance `/accounts` to support POST and include the name field
- add new `/accounts/<id>` endpoint for GET/PUT/DELETE
- update import logic to lookup accounts by number and account type only
- provide unit tests for creating, updating and deleting accounts

## Testing
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `pytest -q tests/test_accounts_crud.py -s` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_685e7abaef00832fa22a6c2ed1e0b554