### PR TITLE
Add account tests and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ python run.py
 Le fichier `tresoperso.db` est placé dans le répertoire courant et peut être
 supprimé en cas de réinitialisation souhaitée.
 
+## Gestion des comptes et import CSV
+
+Depuis l'onglet **Comptes** de l'interface web vous pouvez gérer plusieurs comptes bancaires.
+Chaque import CSV crée automatiquement le compte correspondant s'il n'existe pas encore.
+Si le numéro et le type correspondent à un compte existant, la date d'export est simplement mise à jour au lieu de créer un doublon.
+Utilisez le bouton «Importer CSV» pour sélectionner un fichier et mettre à jour le compte choisi. Un bouton «Supprimer» permet aussi d'effacer un compte.
+
 ## Tests
 
 Avant de lancer la suite de tests, installez les dépendances de développement :

--- a/tests/test_import_endpoint.py
+++ b/tests/test_import_endpoint.py
@@ -34,12 +34,19 @@ def test_reimport_returns_duplicates(client):
     first = import_file(client, csv)
     assert first.status_code == 200
     data1 = first.get_json()
+    acc_id = data1['account']['id']
     assert data1.get('imported') == 2
     assert 'duplicates' not in data1
 
     second = import_file(client, csv)
     assert second.status_code == 200
     data2 = second.get_json()
+    assert data2['account']['id'] == acc_id
     assert not data2.get('errors')
     assert 'duplicates' in data2
     assert len(data2['duplicates']) == 2
+
+    session = models.SessionLocal()
+    accounts = session.query(models.BankAccount).all()
+    session.close()
+    assert len(accounts) == 1


### PR DESCRIPTION
## Summary
- expand account API tests with CRUD coverage
- update import endpoint test to assert account updates
- document how to manage multiple accounts and import CSV files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e7cefe710832fa8d64f91b0407102