### PR TITLE
Add support for new BNP CSV layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,13 @@ pytest
 
 ## Format des fichiers CSV
 
-Pour la BNP : Les champs du CSV doivent être séparés par des point-virgules (`;`). 
-Les fichiers de la bnp ne comportent pas d'entete de colonnes. la premiere ligne decrit le compte bancaire. A partir de la deuxieme ligne se trouvent les transactions.
-Elles sont au format :`date`, `type de transaction`, `moyen de paiement`, `libellé` et
-`montant`. Les colonnes `type de transaction` et `moyen de paiement` sont
-désormais enregistrées dans la base pour chaque opération.
+Pour la BNP, les champs du CSV doivent être séparés par des point‑virgules (`;`).
+La première ligne décrit le compte bancaire sous la forme :
+`type de compte ; nom ; numéro ; date du fichier ; ; solde à la date`.
+La seconde ligne est vide et la troisième contient les en‑têtes :
+`Date opération ; Libellé court ; Type opération ; Libellé opération ; Montant opération en euro`.
+Les lignes suivantes contiennent les opérations au même ordre que ces en‑têtes.
+Les colonnes `type opération` et `libellé court` sont enregistrées dans la base pour chaque opération.
 
 Les montants peuvent contenir un espace comme séparateur de milliers et
 utiliser soit la virgule soit le point pour indiquer les décimales.

--- a/tests/test_parse_csv.py
+++ b/tests/test_parse_csv.py
@@ -57,3 +57,21 @@ def test_parse_csv_trailing_minus():
     assert duplicates == []
     assert len(transactions) == 1
     assert transactions[0]["amount"] == -123.45
+
+
+def test_parse_csv_with_header_and_account_info():
+    csv_data = (
+        "Compte courant;Mon compte;12345678;2021-01-01;;1000,00\n"
+        "\n"
+        "Date operation;Libelle court;Type operation;Libelle operation;Montant operation en euro\n"
+        "2021-01-02;CB;Debit;Achat;-12,34\n"
+        "2021-01-03;VIR;Credit;Salaire;1000,00\n"
+    )
+    transactions, duplicates, errors, info = parse_csv(csv_data)
+
+    assert not errors
+    assert duplicates == []
+    assert len(transactions) == 2
+    assert info["account_type"] == "Compte courant"
+    assert info["number"] == "12345678"
+    assert info["export_date"] == datetime.date(2021, 1, 1)


### PR DESCRIPTION
## Summary
- update README for new BNP CSV layout
- extend `parse_csv` to detect header-based BNP exports and read balance info
- save the account name and initial balance when importing
- expose more account fields in import response
- test parsing of the new BNP CSV format

## Testing
- `pytest tests/test_parse_csv.py::test_parse_csv_with_header_and_account_info -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685e7ec5a74c832f8e6566f4725ef1b9