### PR TITLE
Handle blank lines in CSV

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -337,6 +337,9 @@ def parse_csv(content):
 
     # Skip header/account information lines
     for line_no, row in enumerate(rows[start_idx:], start=start_idx + 1):
+        # Ignore completely empty lines which may appear at the end of the file
+        if not any(cell.strip() for cell in row):
+            continue
         if len(row) < 5:
             errors.append(f'Ligne {line_no}: colonnes manquantes')
             continue

--- a/tests/test_parse_csv.py
+++ b/tests/test_parse_csv.py
@@ -75,3 +75,15 @@ def test_parse_csv_with_header_and_account_info():
     assert info["account_type"] == "Compte courant"
     assert info["number"] == "12345678"
     assert info["export_date"] == datetime.date(2021, 1, 1)
+
+
+def test_parse_csv_trailing_blank_line():
+    csv_data = """Compte courant 12345678 2021-01-01
+2021-01-02;Debit;CB;Achat;-12,34
+
+"""
+    transactions, duplicates, errors, info = parse_csv(csv_data)
+
+    assert not errors
+    assert duplicates == []
+    assert len(transactions) == 1


### PR DESCRIPTION
## Summary
- ignore empty rows when parsing CSVs
- regression test for trailing blank lines

## Testing
- `pytest tests/test_parse_csv.py::test_parse_csv_trailing_blank_line -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685e84780158832f804feb78942e94f4