### PR TITLE
Handle long labels in transactions table

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -25,6 +25,9 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
     width: 95%;
     table-layout: auto;
 }
+#transactions-table.long-label {
+    font-size: 0.75rem;
+}
 #transactions-table td {
     white-space: nowrap;
 }
@@ -63,11 +66,24 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
     width: 2em;
     text-align: right;
 }
+#transactions-table.long-label th:nth-child(1),
+#transactions-table.long-label td:nth-child(1) {
+    width: 1.5em;
+}
 #transactions-table th:nth-child(6),
 #transactions-table td:nth-child(6) {
     width: 100%;
     white-space: normal;
     word-break: break-word;
+}
+#transactions-table.long-label th,
+#transactions-table.long-label td {
+    padding-left: 2px;
+    padding-right: 2px;
+}
+#transactions-table.long-label th:nth-child(6),
+#transactions-table.long-label td:nth-child(6) {
+    width: auto;
 }
 #transactions-table th:nth-child(7),
 #transactions-table td:nth-child(7) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -514,6 +514,22 @@
 
                 tbody.appendChild(tr);
             });
+            adjustLabelColumns();
+        }
+
+        function adjustLabelColumns() {
+            const table = document.getElementById('transactions-table');
+            if (!table) return;
+            table.classList.remove('long-label');
+            const cells = table.querySelectorAll('tbody td:nth-child(6)');
+            for (const td of cells) {
+                const lh = parseFloat(getComputedStyle(td).lineHeight);
+                const lines = Math.round(td.getBoundingClientRect().height / lh);
+                if (lines >= 6) {
+                    table.classList.add('long-label');
+                    break;
+                }
+            }
         }
 
         async function fetchAccounts() {
@@ -761,6 +777,7 @@
 
                 tbody.appendChild(tr);
             });
+            adjustLabelColumns();
         }
 
         document.getElementById('login-form').addEventListener('submit', async e => {


### PR DESCRIPTION
## Summary
- tweak transaction table styles for smaller fonts and padding when labels are long
- add JS helper to detect long "libellé" cells
- reduce star column width when labels span many lines

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685e8811df28832f9261a154c7dfd772