### PR TITLE
Centralize configuration

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,4 +1,5 @@
-from .app import app, run, SessionLocal, CATEGORIES_JSON, load_categories_json, save_categories_json
+from .app import app, run, SessionLocal, load_categories_json, save_categories_json
+from .config import CATEGORIES_JSON
 from .models import init_db
 from .routes import compute_dashboard_averages
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -6,13 +6,11 @@ import webbrowser
 from flask import Flask
 
 from .models import init_db, SessionLocal
+from . import config
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-FRONTEND_DIR = os.path.join(BASE_DIR, '..', 'frontend')
-CATEGORIES_JSON = os.path.join(BASE_DIR, 'categories.json')
-
-app = Flask(__name__, static_folder=FRONTEND_DIR, static_url_path='')
-app.secret_key = os.environ.get('SECRET_KEY', 'dev-secret')
+app = Flask(__name__, static_folder=str(config.FRONTEND_DIR), static_url_path='')
+app.secret_key = config.SECRET_KEY
+CATEGORIES_JSON = config.CATEGORIES_JSON
 
 
 def load_categories_json():

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,28 @@
+import os
+from pathlib import Path
+
+# Load environment variables from a .env file if present
+BASE_DIR = Path(__file__).resolve().parent
+ROOT_DIR = BASE_DIR.parent
+ENV_PATH = ROOT_DIR / '.env'
+
+
+def load_dotenv(path=ENV_PATH):
+    if path.exists():
+        with path.open('r', encoding='utf-8') as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith('#') or '=' not in line:
+                    continue
+                key, val = line.split('=', 1)
+                os.environ.setdefault(key, val)
+
+
+load_dotenv()
+
+FRONTEND_DIR = ROOT_DIR / 'frontend'
+SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-secret')
+DATABASE_URI = os.environ.get('DATABASE_URI', 'sqlite:///tresoperso.db')
+CATEGORIES_JSON = os.environ.get('CATEGORIES_JSON', str(BASE_DIR / 'categories.json'))
+
+__all__ = ['FRONTEND_DIR', 'SECRET_KEY', 'DATABASE_URI', 'CATEGORIES_JSON']

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,11 +1,23 @@
-from sqlalchemy import create_engine, Column, Integer, String, Float, Date, Boolean, ForeignKey, text
+from sqlalchemy import (
+    create_engine,
+    Column,
+    Integer,
+    String,
+    Float,
+    Date,
+    Boolean,
+    ForeignKey,
+    text,
+)
 from sqlalchemy.orm import declarative_base, relationship, sessionmaker
 from flask_login import UserMixin
 from werkzeug.security import generate_password_hash
 import os
 import json
 
-engine = create_engine('sqlite:///tresoperso.db')
+from . import config
+
+engine = create_engine(config.DATABASE_URI)
 SessionLocal = sessionmaker(bind=engine)
 Base = declarative_base()
 

--- a/tests/test_category_options_endpoint.py
+++ b/tests/test_category_options_endpoint.py
@@ -16,7 +16,7 @@ def client(tmp_path, monkeypatch):
     # temp categories.json
     cat_json = tmp_path / "categories.json"
     cat_json.write_text("{}", encoding="utf-8")
-    monkeypatch.setattr(app_module, "CATEGORIES_JSON", str(cat_json))
+    monkeypatch.setattr(app_module.config, "CATEGORIES_JSON", str(cat_json))
     monkeypatch.setattr(models, "__file__", str(tmp_path / "models.py"))
     models.init_db()
     with app_module.app.test_client() as client:


### PR DESCRIPTION
## Summary
- create `backend/config.py` to load settings from environment and `.env`
- use config values in application and models
- re-export configuration constants in `backend.__init__`
- adjust tests to patch configuration path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685eb3e24110832fbf3ce72377f16f07