### PR TITLE
Add user helpers and password hashing tests

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -190,3 +190,35 @@ def init_db():
         session.commit()
 
     session.close()
+
+
+def create_user(username, password, session=None):
+    """Create a user with a hashed password and return the User instance."""
+    close = False
+    if session is None:
+        session = SessionLocal()
+        close = True
+    user = User(username=username, password=generate_password_hash(password))
+    session.add(user)
+    session.commit()
+    if close:
+        session.close()
+    return user
+
+
+def update_user_password(user_id, password, session=None):
+    """Update an existing user's password using a hashed value."""
+    close = False
+    if session is None:
+        session = SessionLocal()
+        close = True
+    user = session.query(User).get(user_id)
+    if not user:
+        if close:
+            session.close()
+        return None
+    user.password = generate_password_hash(password)
+    session.commit()
+    if close:
+        session.close()
+    return user

--- a/tests/test_user_helpers.py
+++ b/tests/test_user_helpers.py
@@ -1,0 +1,37 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from werkzeug.security import check_password_hash
+
+from backend import models
+
+
+def setup_db():
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    models.init_db()
+
+
+def test_create_user_hashes_password():
+    setup_db()
+    user = models.create_user('bob', 'secret')
+    session = models.SessionLocal()
+    stored = session.query(models.User).filter_by(username='bob').first()
+    session.close()
+    assert stored is not None
+    assert stored.password != 'secret'
+    assert check_password_hash(stored.password, 'secret')
+
+
+def test_update_user_password_hashes():
+    setup_db()
+    user = models.create_user('alice', 'oldpw')
+    old_hash = user.password
+    models.update_user_password(user.id, 'newpw')
+    session = models.SessionLocal()
+    updated = session.query(models.User).get(user.id)
+    session.close()
+    assert updated.password != 'newpw'
+    assert updated.password != old_hash
+    assert check_password_hash(updated.password, 'newpw')


### PR DESCRIPTION
## Summary
- add helper functions to create/update user passwords
- exercise password hashing with new tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685eb512a0bc832f94c7ca1b9f53e837