### PR TITLE
Add boolean filtering on transactions

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -412,6 +412,18 @@ def list_transactions():
         except ValueError:
             pass
 
+    favorite = request.args.get('favorite')
+    if favorite in ('true', 'false'):
+        query = query.filter(Transaction.favorite == (favorite == 'true'))
+
+    reconciled = request.args.get('reconciled')
+    if reconciled in ('true', 'false'):
+        query = query.filter(Transaction.reconciled == (reconciled == 'true'))
+
+    to_analyze = request.args.get('to_analyze')
+    if to_analyze in ('true', 'false'):
+        query = query.filter(Transaction.to_analyze == (to_analyze == 'true'))
+
     sort_by = request.args.get('sort_by', 'date')
     sort_column = getattr(Transaction, sort_by, Transaction.date)
     order = request.args.get('order', 'desc')

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -68,7 +68,11 @@
                 <table id="transactions-table">
                     <thead>
                         <tr class="filter-row">
-                            <th></th>
+                            <th><select id="filter-favorite">
+                                <option value="">(Tous)</option>
+                                <option value="true">Oui</option>
+                                <option value="false">Non</option>
+                            </select></th>
                             <th></th>
                             <th class="stack">
                                 <input type="date" id="filter-start-date" />
@@ -100,8 +104,16 @@
                             <th><select id="filter-category"><option value="">(Toutes)</option></select></th>
                             <th><select id="filter-subcategory"><option value="">(Toutes)</option></select></th>
                             <th></th>
-                            <th></th>
-                            <th></th>
+                            <th><select id="filter-reconciled">
+                                <option value="">(Tous)</option>
+                                <option value="true">Oui</option>
+                                <option value="false">Non</option>
+                            </select></th>
+                            <th><select id="filter-toanalyze">
+                                <option value="">(Tous)</option>
+                                <option value="true">Oui</option>
+                                <option value="false">Non</option>
+                            </select></th>
                         </tr>
                         <tr>
                             <th>★</th>
@@ -623,6 +635,9 @@
             const amtOrder = document.getElementById('filter-amount-order').value;
             const cat = document.getElementById('filter-category').value;
             const sub = document.getElementById('filter-subcategory').value;
+            const fav = document.getElementById('filter-favorite').value;
+            const rec = document.getElementById('filter-reconciled').value;
+            const ana = document.getElementById('filter-toanalyze').value;
             if (start) params.set('start_date', start);
             if (end) params.set('end_date', end);
             if (txType) params.set('type', txType);
@@ -632,6 +647,9 @@
             if (maxAmt) params.set('max_amount', maxAmt);
             if (cat) params.set('category', cat);
             if (sub) params.set('subcategory', sub);
+            if (fav === 'true' || fav === 'false') params.set('favorite', fav);
+            if (rec === 'true' || rec === 'false') params.set('reconciled', rec);
+            if (ana === 'true' || ana === 'false') params.set('to_analyze', ana);
             if (amtOrder === 'asc' || amtOrder === 'desc') {
                 params.set('sort_by', 'amount');
                 params.set('order', amtOrder);
@@ -1635,7 +1653,8 @@
             'filter-start-date', 'filter-end-date', 'filter-period',
             'filter-type', 'filter-payment',
             'filter-label', 'filter-min-amount', 'filter-max-amount',
-            'filter-category', 'filter-subcategory', 'filter-amount-order'
+            'filter-category', 'filter-subcategory', 'filter-amount-order',
+            'filter-favorite', 'filter-reconciled', 'filter-toanalyze'
         ];
         filterInputs.forEach(id => {
             const el = document.getElementById(id);

--- a/tests/test_transactions_filters.py
+++ b/tests/test_transactions_filters.py
@@ -1,0 +1,76 @@
+import datetime
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+import backend as app_module
+
+
+@pytest.fixture
+def client():
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    models.init_db()
+    session = models.SessionLocal()
+    session.add_all([
+        models.Transaction(date=datetime.date(2021,1,1), label='T1', amount=10, favorite=True, reconciled=True, to_analyze=True),
+        models.Transaction(date=datetime.date(2021,1,2), label='T2', amount=20, favorite=False, reconciled=False, to_analyze=False),
+    ])
+    session.commit()
+    session.close()
+    with app_module.app.test_client() as client:
+        yield client
+
+
+def login(client):
+    resp = client.post('/login', json={'username': 'admin', 'password': 'admin'})
+    assert resp.status_code == 200
+
+
+def test_filter_favorite(client):
+    login(client)
+    resp = client.get('/transactions?favorite=true')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]['favorite'] is True
+
+    resp = client.get('/transactions?favorite=false')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]['favorite'] is False
+
+
+def test_filter_reconciled(client):
+    login(client)
+    resp = client.get('/transactions?reconciled=true')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]['reconciled'] is True
+
+    resp = client.get('/transactions?reconciled=false')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]['reconciled'] is False
+
+
+def test_filter_to_analyze(client):
+    login(client)
+    resp = client.get('/transactions?to_analyze=true')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]['to_analyze'] is True
+
+    resp = client.get('/transactions?to_analyze=false')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]['to_analyze'] is False
+


### PR DESCRIPTION
## Summary
- add favorite/reconciled/to_analyze filters in frontend UI
- read these values in fetchTransactions and pass query parameters
- support filtering booleans in backend list_transactions endpoint
- cover filters with new tests

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement Flask)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685fe661ffc8832fbe3425d3ac32d58c