### PR TITLE
Load Chart.js from CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,9 @@ macOS afin d'obtenir un
 exécutable natif.
 
 Les bibliothèques JavaScript **Chart.js** et **chartjs-chart-sankey** sont
-fournies localement dans `frontend/lib`, ce qui permet d'exécuter l'interface
-sans connexion réseau.
+à présent chargées depuis le CDN jsDelivr (`https://cdn.jsdelivr.net`).
+Une connexion Internet est donc requise pour afficher correctement les
+graphiques de l'interface.
 
 ## Licence
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,8 +6,8 @@
     <title>Tresoperso</title>
     <link rel="stylesheet" href="base.css">
     <link rel="stylesheet" id="theme-link" href="light.css">
-    <script src="lib/chart.js"></script>
-    <script src="lib/chartjs-chart-sankey.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-sankey"></script>
 </head>
 <body>
     <form id="login-form">

--- a/frontend/lib/chart.js
+++ b/frontend/lib/chart.js
@@ -1,1 +1,0 @@
-/* Placeholder for Chart.js library */

--- a/frontend/lib/chartjs-chart-sankey.js
+++ b/frontend/lib/chartjs-chart-sankey.js
@@ -1,1 +1,0 @@
-/* Placeholder for chartjs-chart-sankey plugin */


### PR DESCRIPTION
## Summary
- load Chart.js and sankey plugin from jsDelivr CDN
- delete placeholder JavaScript files
- document CDN usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685feb50530c832f9a9e4cf5b94fb8b6