### PR TITLE
Add flex layout to rule and favorite filter popups

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -183,6 +183,18 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
     padding: 10px;
     border: 1px solid var(--border-color);
 }
+#rule-overlay .popup,
+#fav-filter-overlay .popup {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+#rule-label-checkboxes,
+#fav-filter-label-checkboxes {
+    display: flex;
+    flex-wrap: wrap;
+}
 #app { display: flex; flex-direction: column; }
 #navbar { position: fixed; top: 0; left: 0; right: 0; border-bottom: 1px solid var(--border-color); background: var(--bg-color); z-index: 1000; }
 #navbar ul { list-style: none; margin: 0; padding: 0; display: flex; }


### PR DESCRIPTION
## Summary
- adjust popup overlays to use flex column layout
- make rule and favorite filter labels wrap nicely

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685febf06428832f9809b05e69c1bec7