### PR TITLE
Fix canvas sizes for category charts

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -160,8 +160,8 @@
                 </select>
                 <canvas id="statsChart" width="400" height="200"></canvas>
                 <div id="category-charts">
-                    <canvas id="incomeChart" width="300" height="300"></canvas>
-                    <canvas id="expenseChart" width="300" height="300"></canvas>
+                <canvas id="incomeChart"></canvas>
+                <canvas id="expenseChart"></canvas>
                 </div>
                 <div id="category-no-data" style="display:none;">No data</div>
                 <canvas id="sankeyChart" width="600" height="300"></canvas>


### PR DESCRIPTION
## Summary
- drop width/height attributes from the income and expense chart canvas tags
- confirm default and mobile CSS rules handle sizing

## Testing
- `make test` *(fails: Could not find a version that satisfies the requirement Flask)*

------
https://chatgpt.com/codex/tasks/task_e_685ffcefc72c832f8855bd9ab44c605a