### PR TITLE
Handle category none filter

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -366,6 +366,9 @@ def list_transactions():
     if category:
         query = query.join(Category).filter(Category.name == category)
 
+    if request.args.get('category_none') in ('true', '1', 'yes'):
+        query = query.filter(Transaction.category_id == None)
+
     tx_type = request.args.get('type')
     if tx_type:
         query = query.filter(Transaction.tx_type == tx_type)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -326,11 +326,14 @@
                 'fav-filter-overlay-subcategory'
             ];
 
-            catSelectIds.forEach(id => {
+           catSelectIds.forEach(id => {
                 const sel = document.getElementById(id);
                 if (!sel) return;
-                const noneText = id === 'filter-category' ? '(Toutes)' : '(Aucune)';
-                sel.innerHTML = `<option value="">${noneText}</option>`;
+                if (id === 'filter-category') {
+                    sel.innerHTML = '<option value="">(Toutes)</option><option value="none">(Aucune)</option>';
+                } else {
+                    sel.innerHTML = '<option value="">(Aucune)</option>';
+                }
             });
 
             subSelectIds.forEach(id => {
@@ -661,7 +664,11 @@
             if (label) params.set('label', label);
             if (minAmt) params.set('min_amount', minAmt);
             if (maxAmt) params.set('max_amount', maxAmt);
-            if (cat) params.set('category', cat);
+            if (cat === 'none') {
+                params.set('category_none', 'true');
+            } else if (cat) {
+                params.set('category', cat);
+            }
             if (sub) params.set('subcategory', sub);
             if (fav === 'true' || fav === 'false') params.set('favorite', fav);
             if (rec === 'true' || rec === 'false') params.set('reconciled', rec);


### PR DESCRIPTION
## Summary
- expand the category filter dropdown to include an `(Aucune)` option
- send `category_none=true` when `(Aucune)` is selected
- support `category_none` query parameter in backend transaction filtering

## Testing
- `pytest -q` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686005e046d4832fbf33e647529d6195