### PR TITLE
Fix category deletion error handling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -918,9 +918,14 @@
                 const del = document.createElement('button');
                 del.textContent = 'Supprimer';
                 del.onclick = async () => {
-                    await fetch('/categories/' + c.id, { method: 'DELETE' });
-                    await refreshCategoryData();
-                    fetchRules();
+                    const resp = await fetch('/categories/' + c.id, { method: 'DELETE' });
+                    const data = await resp.json().catch(() => ({}));
+                    if (resp.ok) {
+                        await refreshCategoryData();
+                        fetchRules();
+                    } else {
+                        alert(data.error || 'Suppression échouée');
+                    }
                 };
                 delTd.appendChild(del);
                 tr.appendChild(delTd);


### PR DESCRIPTION
## Summary
- show an alert when category deletion fails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686006bdd54c832fb160b5b53b239e52