### PR TITLE
Support category_id filter

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -362,9 +362,12 @@ def list_transactions():
         except ValueError:
             pass
 
-    category = request.args.get('category')
-    if category:
-        query = query.join(Category).filter(Category.name == category)
+    category_id = request.args.get('category_id')
+    if category_id:
+        try:
+            query = query.filter(Transaction.category_id == int(category_id))
+        except ValueError:
+            pass
 
     if request.args.get('category_none') in ('true', '1', 'yes'):
         query = query.filter(Transaction.category_id == None)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -667,7 +667,7 @@
             if (cat === 'none') {
                 params.set('category_none', 'true');
             } else if (cat) {
-                params.set('category', cat);
+                params.set('category_id', cat);
             }
             if (sub) params.set('subcategory', sub);
             if (fav === 'true' || fav === 'false') params.set('favorite', fav);


### PR DESCRIPTION
## Summary
- use `category_id` parameter on `/transactions` endpoint
- send `category_id` filter from the frontend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6860078b9508832fb4d77f102dd1052c