### PR TITLE
Ensure delete overlay appears above navbar

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -180,6 +180,7 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
     left: 0;
     width: 100%;
     height: 100%;
+    z-index: 2000;
     background: rgba(0,0,0,0.4);
     display: none;
     align-items: center;


### PR DESCRIPTION
## Summary
- elevate `.overlay` z-index so modals appear above navbar

## Testing
- `pytest -q` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686174cab48c832fa58b475105eda0d9