### PR TITLE
Update category charts layout

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -127,14 +127,17 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
 .settings-col { flex: 1; }
 
 #category-charts {
-    display: flex;
-    justify-content: center;
-    gap: 20px;
+    width: 100%;
+    border-collapse: collapse;
 }
-
+#category-charts, #category-charts td {
+    border: none;
+}
+#category-charts td {
+    width: 50%;
+}
 #category-charts canvas {
-    width: 200px;
-    max-width: 100%;
+    width: 100%;
     height: auto;
 }
 
@@ -284,10 +287,8 @@ body.hide-amounts .amount-input {
     #transactions-table {
         font-size: 0.75rem;
     }
-    #category-charts {
-        flex-direction: column;
-    }
-    #category-charts canvas {
+    #category-charts td {
+        display: block;
         width: 100%;
     }
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -159,10 +159,12 @@
                     <option value="all">Tout</option>
                 </select>
                 <canvas id="statsChart" width="400" height="200"></canvas>
-                <div id="category-charts">
-                <canvas id="incomeChart"></canvas>
-                <canvas id="expenseChart"></canvas>
-                </div>
+                <table id="category-charts">
+                    <tr>
+                        <td><canvas id="incomeChart"></canvas></td>
+                        <td><canvas id="expenseChart"></canvas></td>
+                    </tr>
+                </table>
                 <div id="category-no-data" style="display:none;">No data</div>
                 <div id="sankeyChart" style="width:600px;height:300px;"></div>
             </section>
@@ -1166,7 +1168,7 @@
                 emptyNotice.style.display = 'block';
                 return;
             }
-            chartsDiv.style.display = 'flex';
+            chartsDiv.style.display = 'table';
             emptyNotice.style.display = 'none';
             const ictx = document.getElementById('incomeChart').getContext('2d');
             if (incomeChart) incomeChart.destroy();


### PR DESCRIPTION
## Summary
- display income and expense charts in a table for side-by-side layout
- style the new table and canvases in base CSS
- show the charts table when stats are available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68617b4da9d0832f8ef2b17d47701a7c