### PR TITLE
Set default Chart.js styles

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -290,6 +290,10 @@
         </div>
     </div>
     <script>
+        // Global defaults for all charts
+        Chart.defaults.color = '#eeeeee';
+        Chart.defaults.font.size = 13;
+
         let categoriesData = [];
         let subcategoriesData = [];
         let categoryOptions = [];


### PR DESCRIPTION
## Summary
- set global defaults for Chart.js colors and font size

## Testing
- `make test` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68628c0ec270832f8d6dd2957cbd1181