### PR TITLE
Add subcategory info on category delete errors

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1022,6 +1022,13 @@ def categories(category_id=None):
             }
             for t in category.transactions
         ]
+        subs = [
+            {
+                'id': s.id,
+                'name': s.name,
+            }
+            for s in category.subcategories
+        ]
         session.close()
         return (
             jsonify(
@@ -1031,6 +1038,7 @@ def categories(category_id=None):
                         'deleting this category'
                     ),
                     'transactions': transactions,
+                    'subcategories': subs,
                 }
             ),
             400,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -283,6 +283,8 @@
         </div>
         <div id="delete-error-overlay" class="overlay">
             <div class="popup">
+                <h3>Sous-catégories liées</h3>
+                <ul id="delete-error-subcat-list"></ul>
                 <h3>Transactions liées</h3>
                 <ul id="delete-error-list"></ul>
                 <button id="delete-error-close">Fermer</button>
@@ -937,8 +939,9 @@
                         await refreshCategoryData();
                         fetchRules();
                     } else {
-                        if (data.transactions && data.transactions.length) {
-                            showDeleteError(data.transactions);
+                        if ((data.transactions && data.transactions.length) ||
+                            (data.subcategories && data.subcategories.length)) {
+                            showDeleteError(data.transactions || [], data.subcategories || []);
                         } else {
                             alert(data.error || 'Suppression échouée');
                         }
@@ -1353,6 +1356,7 @@
         const favFilterOverlay = document.getElementById('fav-filter-overlay');
         const manageSubcatsOverlay = document.getElementById('manage-subcats-overlay');
         const delErrorOverlay = document.getElementById('delete-error-overlay');
+        const delErrorSubList = document.getElementById('delete-error-subcat-list');
         const delErrorList = document.getElementById('delete-error-list');
         const delErrorClose = document.getElementById('delete-error-close');
         let manageCatId = null;
@@ -1511,9 +1515,15 @@
         });
         manageSubcatsOverlay.addEventListener('click', e => { if (e.target === manageSubcatsOverlay) manageSubcatsOverlay.style.display = 'none'; });
 
-        function showDeleteError(transactions) {
+        function showDeleteError(transactions, subcats) {
+            delErrorSubList.innerHTML = '';
+            (subcats || []).forEach(s => {
+                const li = document.createElement('li');
+                li.textContent = `${s.id} - ${s.name}`;
+                delErrorSubList.appendChild(li);
+            });
             delErrorList.innerHTML = '';
-            transactions.forEach(t => {
+            (transactions || []).forEach(t => {
                 const li = document.createElement('li');
                 li.textContent = `${formatDate(t.date)} - ${t.label} - ${formatAmount(t.amount)}`;
                 delErrorList.appendChild(li);

--- a/tests/test_categories_endpoint.py
+++ b/tests/test_categories_endpoint.py
@@ -53,6 +53,7 @@ def test_delete_category_with_subcategory_fails(client):
     assert 'error' in data
     assert 'transactions' in data
     assert data['transactions'] == []
+    assert 'subcategories' in data and len(data['subcategories']) == 1
     session = models.SessionLocal()
     cat = session.query(models.Category).get(client.cat_id)
     session.close()
@@ -101,3 +102,4 @@ def test_delete_category_with_transactions_fails(client):
     assert resp.status_code == 400
     data = resp.get_json()
     assert 'transactions' in data and len(data['transactions']) == 1
+    assert 'subcategories' in data and len(data['subcategories']) == 1


### PR DESCRIPTION
## Summary
- include subcategory list in deletion error response from `/categories/<id>`
- display subcategories in delete error overlay
- update unit tests for the new response

## Testing
- `pytest tests/test_categories_endpoint.py::test_delete_category_with_subcategory_fails -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68628ffc898c832f83e911687115cf70