### PR TITLE
Fix sankey chart width

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -166,7 +166,7 @@
                     </tr>
                 </table>
                 <div id="category-no-data" style="display:none;">No data</div>
-                <div id="sankeyChart" style="width:600px;height:300px;margin:1em 0;"></div>
+                <div id="sankeyChart" style="width:90vw;height:300px;margin:1em 0;"></div>
             </section>
 
             <section id="projection-section" style="display:none;">


### PR DESCRIPTION
## Summary
- adjust width of sankey chart on index page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `sqlalchemy` and `flask`)*

------
https://chatgpt.com/codex/tasks/task_e_6865539fa610832f881ccb1967f1341d