### PR TITLE
Add threshold parameter to dashboard

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -694,6 +694,10 @@ def compute_dashboard_averages(session):
 @login_required
 def dashboard():
     session = SessionLocal()
+    try:
+        threshold = float(request.args.get('threshold', 1.5))
+    except ValueError:
+        threshold = 1.5
     filters = session.query(FavoriteFilter).all()
     conditions = [Transaction.favorite == True]
     for f in filters:
@@ -728,7 +732,7 @@ def dashboard():
     )
     for tx in recent_txs:
         cat_avg = cat_avgs.get(tx.category_id)
-        if cat_avg and abs(tx.amount) > 1.5 * cat_avg:
+        if cat_avg and abs(tx.amount) > threshold * cat_avg:
             name = tx.category.name if tx.category else 'Inconnu'
             alerts.append(
                 f"{tx.label} {tx.date.isoformat()} depasse 150% de {name}"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -57,3 +57,11 @@ def test_dashboard_alerts_and_summaries(client):
     assert favs['Shop']['current_total'] == -70
     assert 'Food' in favs
 
+
+def test_dashboard_custom_threshold(client):
+    login(client)
+    resp = client.get('/dashboard?threshold=10')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert not any('Huge expense' in a for a in data['alerts'])
+


### PR DESCRIPTION
## Summary
- expose an optional `threshold` query parameter for `/dashboard`
- base alert comparison on the given threshold
- test custom threshold behavior

## Testing
- `pytest -q` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686564ff2448832fadf4f963713635da