### PR TITLE
Update dashboard alerts structure

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -732,14 +732,26 @@ def dashboard():
     )
     for tx in recent_txs:
         cat_avg = cat_avgs.get(tx.category_id)
+        name = tx.category.name if tx.category else "Inconnu"
         if cat_avg and abs(tx.amount) > threshold * cat_avg:
-            name = tx.category.name if tx.category else 'Inconnu'
             alerts.append(
-                f"{tx.label} {tx.date.isoformat()} depasse 150% de {name}"
+                {
+                    "date": tx.date.isoformat(),
+                    "label": tx.label,
+                    "amount": tx.amount,
+                    "category": name,
+                    "reason": "category_threshold",
+                }
             )
         if abs(tx.amount) > income_avg:
             alerts.append(
-                f"{tx.label} {tx.date.isoformat()} depasse la moyenne revenus"
+                {
+                    "date": tx.date.isoformat(),
+                    "label": tx.label,
+                    "amount": tx.amount,
+                    "category": name,
+                    "reason": "income_threshold",
+                }
             )
 
     current_start = datetime.now().date().replace(day=1)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1261,13 +1261,15 @@
             const container = document.getElementById('dashboard-content');
             container.innerHTML = `<p>Favoris: ${data.favorite_count} | Total 30j: ${formatAmount(data.recent_total)} | Solde: ${formatAmount(data.balance_total)}</p>`;
             if (data.alerts && data.alerts.length) {
-                const ul = document.createElement('ul');
+                const table = document.createElement('table');
+                table.innerHTML = '<thead><tr><th>Date</th><th>Libellé</th><th>Montant</th><th>Catégorie</th><th>Raison</th></tr></thead><tbody></tbody>';
+                const tbody = table.querySelector('tbody');
                 data.alerts.forEach(a => {
-                    const li = document.createElement('li');
-                    li.textContent = a;
-                    ul.appendChild(li);
+                    const tr = document.createElement('tr');
+                    tr.innerHTML = `<td>${formatDate(a.date)}</td><td>${a.label}</td><td class="amount">${formatAmount(a.amount)}</td><td>${a.category}</td><td>${a.reason}</td>`;
+                    tbody.appendChild(tr);
                 });
-                container.appendChild(ul);
+                container.appendChild(table);
             }
             if (data.favorite_summaries && data.favorite_summaries.length) {
                 const table = document.createElement('table');

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -51,7 +51,10 @@ def test_dashboard_alerts_and_summaries(client):
     resp = client.get('/dashboard')
     assert resp.status_code == 200
     data = resp.get_json()
-    assert any('Huge expense' in a for a in data['alerts'])
+    assert any(a['label'] == 'Huge expense' for a in data['alerts'])
+    first = data['alerts'][0]
+    for key in ['date', 'label', 'amount', 'category', 'reason']:
+        assert key in first
     favs = {f['name']: f for f in data['favorite_summaries']}
     assert 'Shop' in favs
     assert favs['Shop']['current_total'] == -70
@@ -63,5 +66,5 @@ def test_dashboard_custom_threshold(client):
     resp = client.get('/dashboard?threshold=10')
     assert resp.status_code == 200
     data = resp.get_json()
-    assert not any('Huge expense' in a for a in data['alerts'])
+    assert not any(a['label'] == 'Huge expense' for a in data['alerts'])
 


### PR DESCRIPTION
## Summary
- refactor backend dashboard alerts to return dictionaries
- render dashboard alerts as a table
- check new alert format in dashboard tests

## Testing
- `pytest -k dashboard -q` *(fails: ModuleNotFoundError for 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686565de5f98832f8108b868a157db38