### PR TITLE
Group dashboard favorites by category

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1273,11 +1273,26 @@
             }
             if (data.favorite_summaries && data.favorite_summaries.length) {
                 const table = document.createElement('table');
-                table.innerHTML = '<thead><tr><th>Favori</th><th>Mois en cours</th><th>Moy. 6 mois</th></tr></thead><tbody></tbody>';
+                table.innerHTML = '<thead><tr><th>Catégorie</th><th>Favoris</th></tr></thead><tbody></tbody>';
                 const tbody = table.querySelector('tbody');
-                data.favorite_summaries.forEach(f => {
+                data.favorite_summaries.forEach(group => {
                     const tr = document.createElement('tr');
-                    tr.innerHTML = `<td>${f.name}</td><td>${formatAmount(f.current_total)}</td><td>${formatAmount(f.six_month_avg)}</td>`;
+                    const tdCat = document.createElement('td');
+                    tdCat.textContent = group.category;
+                    const tdFav = document.createElement('td');
+                    if (group.items && group.items.length) {
+                        const inner = document.createElement('table');
+                        inner.innerHTML = '<thead><tr><th>Favori</th><th>Mois en cours</th><th>Moy. 6 mois</th></tr></thead><tbody></tbody>';
+                        const innerBody = inner.querySelector('tbody');
+                        group.items.forEach(f => {
+                            const row = document.createElement('tr');
+                            row.innerHTML = `<td>${f.name}</td><td>${formatAmount(f.current_total)}</td><td>${formatAmount(f.six_month_avg)}</td>`;
+                            innerBody.appendChild(row);
+                        });
+                        tdFav.appendChild(inner);
+                    }
+                    tr.appendChild(tdCat);
+                    tr.appendChild(tdFav);
                     tbody.appendChild(tr);
                 });
                 container.appendChild(table);

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -55,10 +55,15 @@ def test_dashboard_alerts_and_summaries(client):
     first = data['alerts'][0]
     for key in ['date', 'label', 'amount', 'category', 'reason']:
         assert key in first
-    favs = {f['name']: f for f in data['favorite_summaries']}
+    favs = {}
+    cats = {grp['category']: grp for grp in data['favorite_summaries']}
+    for grp in data['favorite_summaries']:
+        for itm in grp['items']:
+            favs[itm['name']] = itm
     assert 'Shop' in favs
     assert favs['Shop']['current_total'] == -70
     assert 'Food' in favs
+    assert 'Food' in cats
 
 
 def test_dashboard_custom_threshold(client):


### PR DESCRIPTION
## Summary
- restructure `/dashboard` favorite summaries into category groups
- show grouped favorites in dashboard table
- adjust dashboard tests to handle new structure

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68662d0ef8dc832f88626f3066321705