### PR TITLE
Add projection categories table

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -172,6 +172,11 @@
 
             <section id="projection-section" style="display:none;">
                 <h2>Projection</h2>
+                <p id="projection-cat-period"></p>
+                <table id="projection-cat-table">
+                    <thead></thead>
+                    <tbody></tbody>
+                </table>
                 <table id="projection-table">
                     <thead><tr><th>Mois</th><th>Montant</th></tr></thead>
                     <tbody></tbody>
@@ -612,6 +617,7 @@
                     fetchDashboard();
                     fetchStats();
                     fetchProjection();
+                    fetchProjectionCategories();
                     fetchCategoryStats();
                     fetchSankeyStats();
                 }
@@ -637,6 +643,7 @@
                 fetchDashboard();
                 fetchStats();
                 fetchProjection();
+                fetchProjectionCategories();
                 fetchCategoryStats();
                 fetchSankeyStats();
             }
@@ -864,6 +871,7 @@
                 fetchDashboard();
                 fetchStats();
                 fetchProjection();
+                fetchProjectionCategories();
                 fetchCategoryStats();
                 fetchSankeyStats();
             } else {
@@ -1362,12 +1370,45 @@
                 amountCell.appendChild(input);
                 tr.appendChild(amountCell);
 
-                tbody.appendChild(tr);
-            });
+            tbody.appendChild(tr);
+        });
             drawProjectionChart();
         }
 
         document.getElementById('projection-table').addEventListener('input', drawProjectionChart);
+
+        async function fetchProjectionCategories() {
+            const resp = await fetch('/projection/categories');
+            if (!resp.ok) return;
+            const data = await resp.json();
+            document.getElementById('projection-cat-period').textContent = data.period;
+            const table = document.getElementById('projection-cat-table');
+            const thead = table.querySelector('thead');
+            const tbody = table.querySelector('tbody');
+            thead.innerHTML = '';
+            tbody.innerHTML = '';
+            const headRow = document.createElement('tr');
+            headRow.innerHTML = '<th>Catégorie</th>';
+            data.months.forEach(m => {
+                const th = document.createElement('th');
+                th.textContent = m;
+                headRow.appendChild(th);
+            });
+            thead.appendChild(headRow);
+            data.rows.forEach(r => {
+                const tr = document.createElement('tr');
+                const tdCat = document.createElement('td');
+                tdCat.textContent = r.category;
+                tr.appendChild(tdCat);
+                r.values.forEach(v => {
+                    const td = document.createElement('td');
+                    td.textContent = formatAmount(v);
+                    td.className = 'amount';
+                    tr.appendChild(td);
+                });
+                tbody.appendChild(tr);
+            });
+        }
 
         let currentCatBtn = null;
         let currentSubBtn = null;
@@ -1590,6 +1631,7 @@
                 fetchDashboard();
                 fetchStats();
                 fetchProjection();
+                fetchProjectionCategories();
                 fetchCategoryStats();
                 fetchSankeyStats();
                 return;
@@ -1605,6 +1647,7 @@
                 fetchDashboard();
                 fetchStats();
                 fetchProjection();
+                fetchProjectionCategories();
                 fetchCategoryStats();
                 fetchSankeyStats();
             } else {
@@ -1725,6 +1768,9 @@
                 });
                 sidebarButtons.forEach(b => b.classList.remove('selected'));
                 btn.classList.add('selected');
+                if (target === 'projection-section') {
+                    fetchProjectionCategories();
+                }
             });
         });
         if (sidebarButtons.length) {
@@ -1774,6 +1820,7 @@
             fetchTransactions();
             fetchStats();
             fetchProjection();
+            fetchProjectionCategories();
             fetchCategoryStats();
             fetchSankeyStats();
         });
@@ -1854,6 +1901,7 @@
                 fetchDashboard();
                 fetchStats();
                 fetchProjection();
+                fetchProjectionCategories();
                 fetchCategoryStats();
                 fetchSankeyStats();
             }

--- a/tests/test_projection_categories.py
+++ b/tests/test_projection_categories.py
@@ -1,0 +1,56 @@
+import datetime
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+import backend as app_module
+
+class FixedDate(datetime.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2021, 7, 15)
+
+@pytest.fixture
+def client(monkeypatch):
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    models.init_db()
+    session = models.SessionLocal()
+    food = models.Category(name='Food')
+    misc = models.Category(name='Misc')
+    session.add_all([food, misc])
+    session.flush()
+    session.add_all([
+        models.Transaction(date=datetime.date(2020, 8, 10), label='t1', amount=10, category=food),
+        models.Transaction(date=datetime.date(2020, 9, 5), label='t2', amount=5, category=food),
+        models.Transaction(date=datetime.date(2021, 2, 20), label='t3', amount=3, category=food),
+        models.Transaction(date=datetime.date(2021, 6, 1), label='t4', amount=7, category=misc),
+        models.Transaction(date=datetime.date(2021, 7, 1), label='t5', amount=2, category=misc),
+    ])
+    session.commit()
+    session.close()
+    with app_module.app.test_client() as client:
+        yield client
+
+def login(client):
+    resp = client.post('/login', json={'username': 'admin', 'password': 'admin'})
+    assert resp.status_code == 200
+
+def test_projection_categories(client):
+    login(client)
+    resp = client.get('/projection/categories')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['period'] == '2020-08 to 2021-07'
+    assert data['months'][0] == '2020-08'
+    assert data['months'][-1] == '2021-07'
+    rows = {r['category']: r['values'] for r in data['rows']}
+    assert rows['Food'][0] == 10
+    assert rows['Food'][1] == 5
+    assert rows['Food'][6] == 3
+    assert rows['Misc'][10] == 7
+    assert rows['Misc'][11] == 2


### PR DESCRIPTION
## Summary
- add `/projection/categories` route for 12‑month per‑category totals
- show projection totals by category in a new table
- fetch the new data when showing the Projection section
- test per-category monthly totals

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6866b88e4294832fb3c586aa4da06d55