### PR TITLE
Adjust projection categories period

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -911,8 +911,8 @@ def projection_categories():
     session = SessionLocal()
     today = datetime.now().date()
     current_start = today.replace(day=1)
-    start = _shift_month(current_start, -11)
-    end = _shift_month(current_start, 1)
+    start = _shift_month(current_start, -12)
+    end = current_start
     rows = (
         session.query(
             func.strftime('%Y-%m', Transaction.date).label('month'),

--- a/tests/test_projection_categories.py
+++ b/tests/test_projection_categories.py
@@ -45,9 +45,9 @@ def test_projection_categories(client):
     resp = client.get('/projection/categories')
     assert resp.status_code == 200
     data = resp.get_json()
-    assert data['period'] == '2020-08 to 2021-07'
-    assert data['months'][0] == '2020-08'
-    assert data['months'][-1] == '2021-07'
+    assert data['period'] == '2020-07 to 2021-06'
+    assert data['months'][0] == '2020-07'
+    assert data['months'][-1] == '2021-06'
     rows = {r['category']: r['values'] for r in data['rows']}
     assert rows['Food'][0] == 10
     assert rows['Food'][1] == 5


### PR DESCRIPTION
## Summary
- update `projection_categories` endpoint to look at the previous 12 months
- fix unit test expectation for the new period

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866be0a9760832fa669e5ed400495b6