### PR TITLE
Add category average projection

### DIFF
--- a/tests/test_category_average_helper.py
+++ b/tests/test_category_average_helper.py
@@ -1,0 +1,43 @@
+import datetime
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+import backend as app_module
+
+class FixedDate(datetime.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2021, 7, 15)
+
+
+def setup_db(monkeypatch):
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    models.init_db()
+    return models.SessionLocal()
+
+
+def test_compute_category_monthly_averages(monkeypatch):
+    session = setup_db(monkeypatch)
+    food = models.Category(name='Food')
+    misc = models.Category(name='Misc')
+    session.add_all([food, misc])
+    session.flush()
+    session.add_all([
+        models.Transaction(date=datetime.date(2020, 8, 10), label='t1', amount=10, category=food),
+        models.Transaction(date=datetime.date(2020, 9, 5), label='t2', amount=5, category=food),
+        models.Transaction(date=datetime.date(2021, 2, 20), label='t3', amount=3, category=food),
+        models.Transaction(date=datetime.date(2021, 6, 1), label='t4', amount=7, category=misc),
+        models.Transaction(date=datetime.date(2021, 7, 1), label='t5', amount=2, category=misc),
+    ])
+    session.commit()
+    avgs = app_module.compute_category_monthly_averages(session)
+    assert avgs['Food'] == pytest.approx(18/12)
+    assert avgs['Misc'] == pytest.approx(7/12)
+    session.close()
+

--- a/tests/test_projection_category_average.py
+++ b/tests/test_projection_category_average.py
@@ -1,0 +1,50 @@
+import datetime
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+import backend as app_module
+
+class FixedDate(datetime.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2021, 7, 15)
+
+@pytest.fixture
+def client(monkeypatch):
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    models.init_db()
+    session = models.SessionLocal()
+    food = models.Category(name='Food')
+    misc = models.Category(name='Misc')
+    session.add_all([food, misc])
+    session.flush()
+    session.add_all([
+        models.Transaction(date=datetime.date(2020, 8, 10), label='t1', amount=10, category=food),
+        models.Transaction(date=datetime.date(2020, 9, 5), label='t2', amount=5, category=food),
+        models.Transaction(date=datetime.date(2021, 2, 20), label='t3', amount=3, category=food),
+        models.Transaction(date=datetime.date(2021, 6, 1), label='t4', amount=7, category=misc),
+        models.Transaction(date=datetime.date(2021, 7, 1), label='t5', amount=2, category=misc),
+    ])
+    session.commit()
+    session.close()
+    with app_module.app.test_client() as client:
+        yield client
+
+def login(client):
+    resp = client.post('/login', json={'username': 'admin', 'password': 'admin'})
+    assert resp.status_code == 200
+
+def test_projection_category_average(client):
+    login(client)
+    resp = client.get('/projection/categories/average')
+    assert resp.status_code == 200
+    data = {row['category']: row['average'] for row in resp.get_json()}
+    assert data['Food'] == pytest.approx(18/12)
+    assert data['Misc'] == pytest.approx(7/12)
+


### PR DESCRIPTION
## Summary
- compute category averages over the previous year
- expose averages at `/projection/categories/average`
- test helper and new route with fixed data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866beb8dff0832f99ff907047d51f54