### PR TITLE
Add category forecast regression

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 SQLAlchemy
 Flask-Login
+numpy

--- a/tests/test_category_forecast_helper.py
+++ b/tests/test_category_forecast_helper.py
@@ -1,0 +1,45 @@
+import datetime
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+import backend as app_module
+
+class FixedDate(datetime.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2021, 7, 15)
+
+
+def setup_db(monkeypatch):
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    models.init_db()
+    return models.SessionLocal()
+
+
+def test_compute_category_forecast(monkeypatch):
+    session = setup_db(monkeypatch)
+    food = models.Category(name='Food')
+    misc = models.Category(name='Misc')
+    session.add_all([food, misc])
+    session.flush()
+    current_start = datetime.date(2021, 7, 1)
+    start = app_module._shift_month(current_start, -12)
+    for i in range(12):
+        d = app_module._shift_month(start, i)
+        session.add_all([
+            models.Transaction(date=d, label=f'f{i}', amount=2 * i + 3, category=food),
+            models.Transaction(date=d, label=f'm{i}', amount=10, category=misc),
+        ])
+    session.commit()
+    result = app_module.compute_category_forecast(session)
+    session.close()
+    rows = {r['category']: r['values'] for r in result['rows']}
+    assert rows['Food'][0] == pytest.approx(27)
+    assert rows['Food'][-1] == pytest.approx(49)
+    assert all(v == pytest.approx(10) for v in rows['Misc'])

--- a/tests/test_projection_category_forecast.py
+++ b/tests/test_projection_category_forecast.py
@@ -1,0 +1,56 @@
+import datetime
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+import backend as app_module
+
+class FixedDate(datetime.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2021, 7, 15)
+
+
+@pytest.fixture
+def client(monkeypatch):
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    models.init_db()
+    session = models.SessionLocal()
+    food = models.Category(name='Food')
+    misc = models.Category(name='Misc')
+    session.add_all([food, misc])
+    session.flush()
+    current_start = datetime.date(2021, 7, 1)
+    start = app_module._shift_month(current_start, -12)
+    for i in range(12):
+        d = app_module._shift_month(start, i)
+        session.add_all([
+            models.Transaction(date=d, label=f'f{i}', amount=2 * i + 3, category=food),
+            models.Transaction(date=d, label=f'm{i}', amount=10, category=misc),
+        ])
+    session.commit()
+    session.close()
+    with app_module.app.test_client() as client:
+        yield client
+
+
+def login(client):
+    resp = client.post('/login', json={'username': 'admin', 'password': 'admin'})
+    assert resp.status_code == 200
+
+
+def test_projection_category_forecast(client):
+    login(client)
+    resp = client.get('/projection/categories/forecast')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['period'] == '2021-07 to 2022-06'
+    rows = {r['category']: r['values'] for r in data['rows']}
+    assert rows['Food'][0] == pytest.approx(27)
+    assert rows['Food'][-1] == pytest.approx(49)
+    assert all(v == pytest.approx(10) for v in rows['Misc'])


### PR DESCRIPTION
## Summary
- add numpy requirement for regression logic
- implement `compute_category_forecast` using linear regression
- expose `/projection/categories/forecast` endpoint
- test new helper and endpoint on deterministic data

## Testing
- `pip install -q -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866bfa37530832f9f6b2539a20521b7