### PR TITLE
Fix dashboard refresh after favorite toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -758,6 +758,7 @@
                 favBtn.addEventListener('click', async () => {
                     await fetch('/transactions/' + t.id, {method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({favorite: !t.favorite})});
                     fetchTransactions();
+                    fetchDashboard();
                 });
                 favCell.appendChild(favBtn);
                 tr.appendChild(favCell);


### PR DESCRIPTION
## Summary
- update favorite toggle click handler to refresh the dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6867f9c9d9a4832f93d26ebac33baef9