### PR TITLE
Fix getPeriodDates timezone format

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -519,7 +519,8 @@
                     start = null;
                     end = null;
             }
-            const fmt = d => d.toISOString().slice(0, 10);
+            // Format dates using local timezone to avoid day shifts
+            const fmt = d => d.toLocaleDateString('fr-CA');
             return {
                 start: start ? fmt(start) : '',
                 end: end ? fmt(end) : ''


### PR DESCRIPTION
## Summary
- use `toLocaleDateString('fr-CA')` so start and end dates aren't shifted by UTC

## Testing
- `make test` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6867fc63dfc0832fb234d6a9c97ae4e4