### PR TITLE
Implement recurring transaction view

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Tresoperso est une application de gestion de trésorerie personnelle. Elle perme
 - Affichage des transactions dans un tableau filtrable
 - Graphiques d'analyse (donut, Sankey)
 - Projection de trésorerie basée sur l'historique
+- Visualisation des transactions récurrentes
+
+La page **Récurrentes** affiche les opérations récurrentes détectées sur les six
+derniers mois. Deux transactions ou plus sont groupées lorsqu'elles partagent le
+même libellé (hors chiffres) et que leurs montants sont compris entre 80&nbsp;% et
+130&nbsp;% de la moyenne du groupe.
 
 ## Lancement rapide
 

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -3,6 +3,7 @@ from flask_login import login_required
 from sqlalchemy import func, or_, and_, case
 from datetime import datetime, timedelta
 import numpy as np
+import re
 
 from .app import app, load_categories_json, save_categories_json
 from .models import (
@@ -650,6 +651,67 @@ def stats_sankey():
                 'value': neg,
                 'sign': -1,
             })
+    return jsonify(result)
+
+
+@app.route('/stats/recurrents')
+@login_required
+def stats_recurrents():
+    """Return recurring transactions for the last six months."""
+    month = request.args.get('month')
+    if month:
+        try:
+            current_first = datetime.strptime(month + '-01', '%Y-%m-%d').date()
+        except ValueError:
+            current_first = datetime.now().date().replace(day=1)
+    else:
+        current_first = datetime.now().date().replace(day=1)
+
+    start = _shift_month(current_first, -5)
+    end = _shift_month(current_first, 1) - timedelta(days=1)
+
+    session = SessionLocal()
+    rows = (
+        session.query(Transaction)
+        .filter(Transaction.date >= start)
+        .filter(Transaction.date <= end)
+        .all()
+    )
+    session.close()
+
+    groups = {}
+    for tx in rows:
+        key = re.sub(r"\d+", "", tx.label).strip().lower()
+        groups.setdefault(key, []).append(tx)
+
+    result = []
+    for txs in groups.values():
+        if len(txs) < 2:
+            continue
+        avg = sum(abs(t.amount) for t in txs) / len(txs)
+        if not all(0.8 * avg <= abs(t.amount) <= 1.3 * avg for t in txs):
+            continue
+        txs.sort(key=lambda t: t.date)
+        cat = txs[0].category
+        item = {
+            'day': txs[0].date.day,
+            'category': {
+                'id': cat.id if cat else None,
+                'name': cat.name if cat else None,
+                'color': cat.color if cat else ''
+            },
+            'transactions': [
+                {
+                    'date': t.date.isoformat(),
+                    'label': t.label,
+                    'amount': t.amount,
+                }
+                for t in txs
+            ]
+        }
+        result.append(item)
+
+    result.sort(key=lambda r: r['day'])
     return jsonify(result)
 
 

--- a/frontend/base.css
+++ b/frontend/base.css
@@ -283,6 +283,27 @@ body.hide-amounts .amount-input {
     visibility: hidden;
 }
 
+#recurrents-calendar {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 4px;
+    max-width: 350px;
+}
+#recurrents-calendar .day {
+    border: 1px solid var(--border-color);
+    min-height: 40px;
+    position: relative;
+    padding: 2px;
+}
+.rec-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    position: absolute;
+    bottom: 2px;
+    right: 2px;
+}
+
 @media (max-width: 600px) {
     #transactions-table {
         font-size: 0.75rem;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -30,6 +30,7 @@
                     <div class="menu-header">Analyses</div>
                     <ul class="submenu">
                         <li><button data-target="stats-section">Statistiques</button></li>
+                        <li><button data-target="recurrents-section">Récurrentes</button></li>
                         <li><button data-target="projection-section">Projections</button></li>
                     </ul>
                 </li>
@@ -172,6 +173,11 @@
                 <div id="financialSankey"></div>
             </section>
 
+            <section id="recurrents-section" style="display:none;">
+                <h2>Transactions récurrentes</h2>
+                <div id="recurrents-calendar"></div>
+            </section>
+
             <section id="projection-section" style="display:none;">
                 <h2>Projection</h2>
                 <p id="projection-cat-period"></p>
@@ -305,6 +311,13 @@
                 <h3>Transactions liées</h3>
                 <ul id="delete-error-list"></ul>
                 <button id="delete-error-close">Fermer</button>
+            </div>
+        </div>
+        <div id="recurrents-overlay" class="overlay">
+            <div class="popup">
+                <h3 id="recurrents-title"></h3>
+                <ul id="recurrents-list"></ul>
+                <button id="recurrents-close">Fermer</button>
             </div>
         </div>
     </div>
@@ -1489,6 +1502,50 @@
             });
         }
 
+        async function fetchRecurrents() {
+            const today = new Date();
+            const month = today.toISOString().slice(0,7);
+            const resp = await fetch(`/stats/recurrents?month=${month}`);
+            if (!resp.ok) return;
+            const data = await resp.json();
+            const container = document.getElementById('recurrents-calendar');
+            if (!container) return;
+            container.innerHTML = '';
+            const daysInMonth = new Date(today.getFullYear(), today.getMonth()+1, 0).getDate();
+            for (let i=1;i<=daysInMonth;i++) {
+                const div = document.createElement('div');
+                div.className = 'day';
+                div.textContent = i;
+                div.dataset.day = i;
+                container.appendChild(div);
+            }
+            data.forEach(rec => {
+                const cell = container.querySelector(`div[data-day="${rec.day}"]`);
+                if (!cell) return;
+                const dot = document.createElement('span');
+                dot.className = 'rec-dot';
+                dot.style.background = rec.category.color || 'gray';
+                dot.title = rec.category.name || '';
+                dot.addEventListener('click', () => showRecurrent(rec));
+                cell.appendChild(dot);
+            });
+        }
+
+        function showRecurrent(rec) {
+            const overlay = document.getElementById('recurrents-overlay');
+            const title = document.getElementById('recurrents-title');
+            const list = document.getElementById('recurrents-list');
+            if (!overlay || !title || !list) return;
+            title.textContent = rec.category.name || '';
+            list.innerHTML = '';
+            rec.transactions.forEach(t => {
+                const li = document.createElement('li');
+                li.textContent = `${formatDate(t.date)} - ${t.label} - ${formatAmount(t.amount)}`;
+                list.appendChild(li);
+            });
+            overlay.style.display = 'flex';
+        }
+
         let currentCatBtn = null;
         let currentSubBtn = null;
         let currentRuleBtn = null;
@@ -1503,6 +1560,8 @@
         const delErrorSubList = document.getElementById('delete-error-subcat-list');
         const delErrorList = document.getElementById('delete-error-list');
         const delErrorClose = document.getElementById('delete-error-close');
+        const recurrentsOverlay = document.getElementById('recurrents-overlay');
+        const recurrentsClose = document.getElementById('recurrents-close');
         let manageCatId = null;
 
         function showPopupAt(overlay, x, y) {
@@ -1677,6 +1736,8 @@
 
         delErrorOverlay.addEventListener('click', e => { if (e.target === delErrorOverlay) delErrorOverlay.style.display = 'none'; });
         if (delErrorClose) delErrorClose.addEventListener('click', () => { delErrorOverlay.style.display = 'none'; });
+        if (recurrentsClose) recurrentsClose.addEventListener('click', () => { recurrentsOverlay.style.display = 'none'; });
+        recurrentsOverlay.addEventListener('click', e => { if (e.target === recurrentsOverlay) recurrentsOverlay.style.display = 'none'; });
 
         function showDuplicates(dups, accountId) {
             const list = document.getElementById('duplicate-list');
@@ -1839,7 +1900,7 @@
             saveFavoriteFilter();
         });
 
-        const sectionIds = ['transactions-section', 'accounts-section', 'dashboard-section', 'stats-section', 'projection-section', 'settings-section'];
+        const sectionIds = ['transactions-section', 'accounts-section', 'dashboard-section', 'stats-section', 'recurrents-section', 'projection-section', 'settings-section'];
         const sidebarButtons = document.querySelectorAll('#navbar button[data-target]');
         sidebarButtons.forEach(btn => {
             btn.addEventListener('click', () => {
@@ -1853,6 +1914,8 @@
                     fetchProjection();
                     fetchProjectionCategories();
                     fetchProjectionFuture();
+                } else if (target === 'recurrents-section') {
+                    fetchRecurrents();
                 }
             });
         });

--- a/tests/test_recurrents_endpoint.py
+++ b/tests/test_recurrents_endpoint.py
@@ -1,0 +1,57 @@
+import datetime
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+import backend as app_module
+
+class FixedDate(datetime.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2021, 5, 15)
+
+@pytest.fixture
+def client(monkeypatch):
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    models.init_db()
+    session = models.SessionLocal()
+    cat = models.Category(name='Sub', color='red')
+    session.add(cat)
+    session.flush()
+    session.add_all([
+        models.Transaction(date=datetime.date(2020,12,5), label='Abo 01', amount=-50, category=cat),
+        models.Transaction(date=datetime.date(2021,1,5), label='Abo 02', amount=-52, category=cat),
+        models.Transaction(date=datetime.date(2021,2,5), label='Abo 03', amount=-48, category=cat),
+        models.Transaction(date=datetime.date(2021,3,5), label='Gym 01', amount=-10, category=cat),
+        models.Transaction(date=datetime.date(2021,4,5), label='Gym 02', amount=-30, category=cat),
+        models.Transaction(date=datetime.date(2021,1,20), label='Unique 01', amount=-5, category=cat),
+    ])
+    session.commit()
+    session.close()
+    with app_module.app.test_client() as client:
+        yield client
+
+
+def login(client):
+    resp = client.post('/login', json={'username': 'admin', 'password': 'admin'})
+    assert resp.status_code == 200
+
+
+def test_recurrents_endpoint(client):
+    login(client)
+    resp = client.get('/stats/recurrents?month=2021-05')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    rec = data[0]
+    assert rec['day'] == 5
+    assert rec['category']['name'] == 'Sub'
+    assert len(rec['transactions']) == 3
+    for t in rec['transactions']:
+        assert all(k in t for k in ['date', 'label', 'amount'])


### PR DESCRIPTION
## Summary
- support recurring transaction detection in backend
- add 'Récurrentes' page and calendar view
- display recurrence dots with overlay details
- style calendar components
- test `/stats/recurrents` endpoint
- document recurring transaction page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6868057729f8832f8560c4109bb4c7a1