### PR TITLE
Fix recurring transaction detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Tresoperso est une application de gestion de trésorerie personnelle. Elle perme
 
 La page **Récurrentes** affiche les opérations récurrentes détectées sur les six
 derniers mois. Deux transactions ou plus sont groupées lorsqu'elles partagent le
-même libellé (hors chiffres) et que leurs montants sont compris entre 80&nbsp;% et
+même libellé (chiffres et noms de mois ignorés) et que leurs montants sont compris entre 80&nbsp;% et
 130&nbsp;% de la moyenne du groupe.
 
 ## Lancement rapide

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -681,7 +681,7 @@ def stats_recurrents():
 
     groups = {}
     for tx in rows:
-        key = re.sub(r"\d+", "", tx.label).strip().lower()
+        key = _normalize_label(tx.label)
         groups.setdefault(key, []).append(tx)
 
     result = []
@@ -713,6 +713,24 @@ def stats_recurrents():
 
     result.sort(key=lambda r: r['day'])
     return jsonify(result)
+
+
+_MONTH_NAMES = [
+    'janvier', 'février', 'fevrier', 'mars', 'avril', 'mai', 'juin',
+    'juillet', 'août', 'aout', 'septembre', 'octobre', 'novembre',
+    'décembre', 'decembre',
+    'jan', 'feb', 'fev', 'mar', 'apr', 'avr', 'may', 'jun', 'jul',
+    'aug', 'aou', 'sep', 'oct', 'nov', 'dec'
+]
+
+
+def _normalize_label(label):
+    """Return a simplified label for recurrence grouping."""
+    s = re.sub(r"\d+", "", label.lower())
+    for name in _MONTH_NAMES:
+        s = s.replace(name, '')
+    s = re.sub(r"\s+", " ", s)
+    return s.strip()
 
 
 def _shift_month(date, offset):

--- a/tests/test_recurrents_endpoint.py
+++ b/tests/test_recurrents_endpoint.py
@@ -55,3 +55,20 @@ def test_recurrents_endpoint(client):
     assert len(rec['transactions']) == 3
     for t in rec['transactions']:
         assert all(k in t for k in ['date', 'label', 'amount'])
+
+
+def test_recurrents_month_names(client):
+    session = models.SessionLocal()
+    cat = session.query(models.Category).first()
+    session.add_all([
+        models.Transaction(date=datetime.date(2021, 3, 6), label='Loan janvier', amount=-1000, category=cat),
+        models.Transaction(date=datetime.date(2021, 4, 6), label='Loan fevrier', amount=-1000, category=cat),
+    ])
+    session.commit()
+    session.close()
+
+    login(client)
+    resp = client.get('/stats/recurrents?month=2021-05')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert any(rec['day'] == 6 and len(rec['transactions']) == 2 for rec in data)


### PR DESCRIPTION
## Summary
- normalize labels with month names ignored
- ensure recurrents endpoint groups labels with month names
- document that month names are ignored
- add regression test for month-name labels

## Testing
- `pytest tests/test_recurrents_endpoint.py::test_recurrents_month_names -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6867fd8cc248832fa70e5d0b23548450