### PR TITLE
Fix run.py import style

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,4 +1,3 @@
-from backend 
-import run
+from backend import run
 if __name__ == '__main__':
     run()


### PR DESCRIPTION
## Summary
- fix import statement formatting for run module

## Testing
- `python -m py_compile run.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68681aaa533c832f8c9e486ee1d1844e