### PR TITLE
Use PBKDF2 hashing for user passwords

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,6 +1,6 @@
-from .app import app, run, SessionLocal, load_categories_json, save_categories_json
+from .app import app, run, load_categories_json, save_categories_json
 from .config import CATEGORIES_JSON
-from .models import init_db
+from .models import init_db, SessionLocal
 from .routes import compute_dashboard_averages
 
 __all__ = [

--- a/backend/app.py
+++ b/backend/app.py
@@ -7,12 +7,12 @@ from flask import Flask
 
 from . import config
 from .models import init_db
-from . import auth  # noqa: F401
-from . import routes  # noqa: F401
 
 app = Flask(__name__, static_folder=str(config.FRONTEND_DIR), static_url_path='')
 app.secret_key = config.SECRET_KEY
 CATEGORIES_JSON = config.CATEGORIES_JSON
+
+from . import auth  # noqa: F401
 
 
 def load_categories_json():
@@ -42,3 +42,6 @@ def run():
     init_db()
     threading.Timer(1, open_browser).start()
     app.run(host='0.0.0.0')
+
+
+from . import routes  # noqa: F401


### PR DESCRIPTION
## Summary
- hash new passwords with `pbkdf2:sha256` and a 16 byte salt
- reload created users so returned objects stay attached
- adjust app initialization to avoid circular imports
- expose `SessionLocal` via `backend` package

## Testing
- `pytest tests/test_user_helpers.py -q`
- `pytest` *(fails: various endpoint tests return 500 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68683ef20148832fadba4c33017dad0c