### PR TITLE
Validate account balance inputs

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -86,14 +86,16 @@ def account_balance(account_id):
         try:
             acc.initial_balance = float(data['initial_balance'])
         except (TypeError, ValueError):
-            pass
+            session.close()
+            return jsonify({'error': 'invalid balance'}), 400
     if 'balance_date' in data:
         val = data['balance_date']
         if val:
             try:
                 acc.balance_date = backend.datetime.strptime(val, '%Y-%m-%d').date()
             except ValueError:
-                pass
+                session.close()
+                return jsonify({'error': 'invalid balance'}), 400
         else:
             acc.balance_date = None
     session.commit()

--- a/tests/test_account_balance_endpoint.py
+++ b/tests/test_account_balance_endpoint.py
@@ -1,0 +1,68 @@
+import datetime
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+import backend as app_module
+
+@pytest.fixture
+def client(monkeypatch):
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    monkeypatch.setattr(app_module, 'datetime', datetime.datetime)
+    models.init_db()
+    session = models.SessionLocal()
+    acc = models.BankAccount(account_type='Compte', number='123')
+    session.add(acc)
+    session.commit()
+    acc_id = acc.id
+    session.close()
+    with app_module.app.test_client() as client:
+        client.acc_id = acc_id
+        yield client
+
+def login(client):
+    resp = client.post('/login', json={'username': 'admin', 'password': 'admin'})
+    assert resp.status_code == 200
+
+def test_invalid_initial_balance_returns_error(client):
+    login(client)
+    resp = client.put(f'/accounts/{client.acc_id}/balance', json={'initial_balance': 'oops'})
+    assert resp.status_code == 400
+    assert resp.get_json() == {'error': 'invalid balance'}
+    session = models.SessionLocal()
+    acc = session.query(models.BankAccount).get(client.acc_id)
+    session.close()
+    assert acc.initial_balance == 0
+
+def test_invalid_balance_date_returns_error(client):
+    login(client)
+    resp = client.put(
+        f'/accounts/{client.acc_id}/balance',
+        json={'balance_date': '2021-13-01'},
+    )
+    assert resp.status_code == 400
+    assert resp.get_json() == {'error': 'invalid balance'}
+    session = models.SessionLocal()
+    acc = session.query(models.BankAccount).get(client.acc_id)
+    session.close()
+    assert acc.balance_date is None
+
+def test_update_balance_success(client):
+    login(client)
+    resp = client.put(
+        f'/accounts/{client.acc_id}/balance',
+        json={'initial_balance': '12.5', 'balance_date': '2021-06-01'},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['initial_balance'] == 12.5
+    assert data['balance_date'] == '2021-06-01'
+    session = models.SessionLocal()
+    acc = session.query(models.BankAccount).get(client.acc_id)
+    session.close()
+    assert acc.initial_balance == 12.5
+    assert acc.balance_date == datetime.date(2021, 6, 1)


### PR DESCRIPTION
## Summary
- validate account balance parsing
- return `{'error': 'invalid balance'}` on conversion failure
- cover new behaviour with tests

## Testing
- `pytest tests/test_account_balance_endpoint.py -q`
- `pytest -q` *(fails: IntegrityError etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686844da8620832fbc905b3af29690fb