### PR TITLE
Validate transaction category IDs

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -3,7 +3,12 @@ import datetime as datetime
 from .app import app, run, load_categories_json, save_categories_json
 from .config import CATEGORIES_JSON
 from .models import init_db, SessionLocal
-from .routes import compute_dashboard_averages
+from .routes import (
+    compute_dashboard_averages,
+    compute_category_monthly_averages,
+    compute_category_forecast,
+    _shift_month,
+)
 
 __all__ = [
     'app',
@@ -14,5 +19,8 @@ __all__ = [
     'save_categories_json',
     'init_db',
     'compute_dashboard_averages',
+    'compute_category_monthly_averages',
+    'compute_category_forecast',
+    '_shift_month',
     'datetime',
 ]

--- a/backend/models.py
+++ b/backend/models.py
@@ -177,7 +177,7 @@ def init_db():
         session.commit()
 
     # Synchronize categories and subcategories from categories.json
-    path = os.path.join(os.path.dirname(__file__), 'categories.json')
+    path = config.CATEGORIES_JSON
     if os.path.exists(path):
         with open(path, 'r', encoding='utf-8') as f:
             data = json.load(f)

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -511,9 +511,21 @@ def update_transaction(tx_id):
 
     data = request.get_json() or {}
     if 'category_id' in data:
-        tx.category_id = data['category_id'] or None
+        cat_id = data['category_id'] or None
+        if cat_id is not None:
+            exists = session.query(models.Category).get(cat_id)
+            if not exists:
+                session.close()
+                return jsonify({'error': 'invalid category'}), 400
+        tx.category_id = cat_id
     if 'subcategory_id' in data:
-        tx.subcategory_id = data['subcategory_id'] or None
+        sub_id = data['subcategory_id'] or None
+        if sub_id is not None:
+            exists = session.query(models.Subcategory).get(sub_id)
+            if not exists:
+                session.close()
+                return jsonify({'error': 'invalid category'}), 400
+        tx.subcategory_id = sub_id
     if 'favorite' in data:
         tx.favorite = bool(data['favorite'])
     if 'reconciled' in data:
@@ -696,7 +708,6 @@ def stats_recurrents():
         .filter(models.Transaction.date <= end)
         .all()
     )
-    session.close()
 
     groups = {}
     for tx in rows:
@@ -736,6 +747,7 @@ def stats_recurrents():
         result.append(item)
 
     result.sort(key=lambda r: r['day'])
+    session.close()
     return jsonify(result)
 
 

--- a/tests/test_transactions_endpoint.py
+++ b/tests/test_transactions_endpoint.py
@@ -1,0 +1,66 @@
+import datetime
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+import backend as app_module
+
+
+@pytest.fixture
+def client():
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    models.init_db()
+    session = models.SessionLocal()
+    cat = models.Category(name='Food', color='red')
+    sub = models.Subcategory(name='Meal', category=cat, color='red')
+    tx = models.Transaction(
+        date=datetime.date(2021, 1, 1),
+        label='Lunch',
+        amount=-10,
+        category=cat,
+        subcategory=sub,
+    )
+    session.add_all([cat, sub, tx])
+    session.commit()
+    tx_id = tx.id
+    cat_id = cat.id
+    sub_id = sub.id
+    session.close()
+    with app_module.app.test_client() as client:
+        client.tx_id = tx_id
+        client.cat_id = cat_id
+        client.sub_id = sub_id
+        yield client
+
+
+def login(client):
+    resp = client.post('/login', json={'username': 'admin', 'password': 'admin'})
+    assert resp.status_code == 200
+
+
+def test_put_transaction_invalid_category(client):
+    login(client)
+    resp = client.put(f'/transactions/{client.tx_id}', json={'category_id': 9999})
+    assert resp.status_code == 400
+    assert resp.get_json() == {'error': 'invalid category'}
+    session = models.SessionLocal()
+    tx = session.query(models.Transaction).get(client.tx_id)
+    session.close()
+    assert tx.category_id == client.cat_id
+
+
+def test_put_transaction_invalid_subcategory(client):
+    login(client)
+    resp = client.put(
+        f'/transactions/{client.tx_id}', json={'subcategory_id': 9999}
+    )
+    assert resp.status_code == 400
+    assert resp.get_json() == {'error': 'invalid category'}
+    session = models.SessionLocal()
+    tx = session.query(models.Transaction).get(client.tx_id)
+    session.close()
+    assert tx.subcategory_id == client.sub_id


### PR DESCRIPTION
## Summary
- check that provided category and subcategory IDs exist when updating a transaction
- expose helper functions from the backend package
- load categories.json from configured path so tests can override it
- test invalid IDs for the transaction update endpoint
- avoid DetachedInstanceError in recurring stats by closing the session later

## Testing
- `pytest tests/test_transactions_endpoint.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686846dcd390832f94dbd2d0e8221c49