### PR TITLE
Sanitize CSV labels starting with formula characters

### DIFF
--- a/backend/csv_utils.py
+++ b/backend/csv_utils.py
@@ -95,7 +95,10 @@ def parse_csv(content):
         date_str = row[0]
         tx_type = row[1]
         payment_method = row[2]
-        label = row[3]
+        label = row[3].strip()
+        if label.startswith(('=', '+', '-', '@')):
+            label = "'" + label
+        
         amount_str = row[4]
 
         if not (date_str and label and amount_str):

--- a/tests/test_parse_csv.py
+++ b/tests/test_parse_csv.py
@@ -1,4 +1,5 @@
 import datetime
+import pytest
 
 from backend.csv_utils import parse_csv
 
@@ -87,3 +88,14 @@ def test_parse_csv_trailing_blank_line():
     assert not errors
     assert duplicates == []
     assert len(transactions) == 1
+
+
+@pytest.mark.parametrize("label", ["=1+2", "+test", "-cmd", "@SUM"])
+def test_parse_csv_sanitizes_label(label):
+    csv_data = f"""Compte courant 12345678 2021-01-01
+2021-01-02;Debit;CB;{label};1,00
+"""
+    transactions, duplicates, errors, info = parse_csv(csv_data)
+
+    assert not errors
+    assert transactions[0]["label"] == "'" + label


### PR DESCRIPTION
## Summary
- neutralize dangerous spreadsheet formula prefixes in `parse_csv`
- test that labels starting with `=`, `+`, `-` and `@` get sanitized

## Testing
- `pytest -q` *(fails: 9 failed, 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68684a7a1570832f9aa2d37dc35b465d