### PR TITLE
Set secure session cookie flags

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -16,6 +16,12 @@ from .models import init_db
 
 app = Flask(__name__, static_folder=str(config.FRONTEND_DIR), static_url_path='')
 app.secret_key = config.SECRET_KEY
+# Secure session cookie settings
+# - SESSION_COOKIE_HTTPONLY prevents JavaScript access to the cookie.
+# - SESSION_COOKIE_SECURE ensures the cookie is only sent over HTTPS.
+app.config['SESSION_COOKIE_HTTPONLY'] = True
+app.config['SESSION_COOKIE_SECURE'] = True
+
 CATEGORIES_JSON = config.CATEGORIES_JSON
 
 from . import auth  # noqa: F401


### PR DESCRIPTION
## Summary
- set SESSION_COOKIE_HTTPONLY and SESSION_COOKIE_SECURE on Flask app
- document why these settings are enabled

## Testing
- `pytest -q`
- `pytest tests/test_dashboard.py::test_dashboard_alerts_and_summaries -q`
- `pytest tests/test_stats_endpoint.py::test_stats_start_date_filter -q` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_68684c784cf4832fa6cc8c4be9875ff5