### PR TITLE
Enhance recurrent stats

### DIFF
--- a/tests/test_recurrents_endpoint.py
+++ b/tests/test_recurrents_endpoint.py
@@ -54,6 +54,9 @@ def test_recurrents_endpoint(client):
     assert rec['day'] == 5
     assert rec['category']['name'] == 'Sub'
     assert len(rec['transactions']) == 3
+    assert rec['average_amount'] == pytest.approx(-50)
+    assert rec['last_date'] == '2021-02-05'
+    assert rec['frequency'] == 'monthly'
     for t in rec['transactions']:
         assert all(k in t for k in ['date', 'label', 'amount'])
 
@@ -64,4 +67,5 @@ def test_recurrents_date_variation(client):
     data = resp.get_json()
     labels = [t['label'] for rec in data for t in rec['transactions']]
     assert 'Club 01' not in labels
+    assert 'Unique 01' not in labels
 


### PR DESCRIPTION
## Summary
- cluster recurring transactions by fuzzy label similarity
- widen the amount tolerance to ±30% and compute additional stats
- test new fields returned by `/stats/recurrents`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest tests/test_recurrents_endpoint.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6868c7194b34832f9ffc590f99f0afb2