### PR TITLE
Add recurrent summary API and frontend integration

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1561,7 +1561,7 @@
 
             populateRecurrentsList();
             drawRecurrentsChart();
-            updateRecurrentsTotals();
+            await updateRecurrentsTotals();
         }
 
         function showRecurrent(rec) {
@@ -1593,21 +1593,21 @@
             });
         }
 
-        function updateRecurrentsTotals() {
+        async function updateRecurrentsTotals() {
             const totIn = document.getElementById('recurrents-total-in');
             const totOut = document.getElementById('recurrents-total-out');
             const balance = document.getElementById('recurrents-balance');
             const total = document.getElementById('recurrents-total');
-            let pos = 0, neg = 0;
-            recurrentsData.forEach(r => {
-                const avg = r.transactions.reduce((s,t) => s + t.amount, 0) / r.transactions.length;
-                if (avg >= 0) pos += avg; else neg += Math.abs(avg);
-            });
+            const today = new Date();
+            const month = today.toISOString().slice(0,7);
+            const resp = await fetch(`/stats/recurrents/summary?month=${month}`);
+            if (!resp.ok) return;
+            const data = await resp.json();
             const hide = localStorage.getItem('hideAmounts') === 'true';
-            if (totIn) totIn.textContent = `Entrées: ${hide ? '•••' : formatAmount(pos)}`;
-            if (totOut) totOut.textContent = `Sorties: ${hide ? '•••' : formatAmount(neg)}`;
-            if (balance) balance.textContent = `Solde: ${hide ? '•••' : formatAmount(pos-neg)}`;
-            if (total) total.textContent = `Total récurrent: ${hide ? '•••' : formatAmount(pos+neg)}`;
+            if (totIn) totIn.textContent = `Entrées: ${hide ? '•••' : formatAmount(data.positive)}`;
+            if (totOut) totOut.textContent = `Sorties: ${hide ? '•••' : formatAmount(data.negative)}`;
+            if (balance) balance.textContent = `Solde: ${hide ? '•••' : formatAmount(data.balance)}`;
+            if (total) total.textContent = `Total récurrent: ${hide ? '•••' : formatAmount(data.recurrent)}`;
         }
 
         function populateRecurrentsList() {

--- a/tests/test_recurrents_summary.py
+++ b/tests/test_recurrents_summary.py
@@ -1,0 +1,53 @@
+import datetime
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+import backend as app_module
+
+
+@pytest.fixture
+def client(monkeypatch):
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    monkeypatch.setattr(app_module, 'datetime', datetime.datetime)
+    models.init_db()
+    session = models.SessionLocal()
+    acc = models.BankAccount(name='Main', initial_balance=200)
+    cat = models.Category(name='Sub', color='red')
+    session.add_all([acc, cat])
+    session.flush()
+    session.add_all([
+        models.Transaction(date=datetime.date(2020,12,5), label='Abo 01', amount=-50, category=cat, account=acc),
+        models.Transaction(date=datetime.date(2021,1,5), label='Abo 02', amount=-52, category=cat, account=acc),
+        models.Transaction(date=datetime.date(2021,2,5), label='Abo 03', amount=-48, category=cat, account=acc),
+        models.Transaction(date=datetime.date(2021,1,1), label='Club 01', amount=-20, category=cat, account=acc),
+        models.Transaction(date=datetime.date(2021,2,25), label='Club 02', amount=-21, category=cat, account=acc),
+        models.Transaction(date=datetime.date(2021,1,20), label='Unique 01', amount=-5, category=cat, account=acc),
+        models.Transaction(date=datetime.date(2021,5,10), label='Salary', amount=1000, account=acc),
+        models.Transaction(date=datetime.date(2021,5,15), label='Groceries', amount=-100, category=cat, account=acc),
+        models.Transaction(date=datetime.date(2021,5,20), label='Stuff', amount=-30, category=cat, account=acc),
+    ])
+    session.commit()
+    session.close()
+    with app_module.app.test_client() as client:
+        yield client
+
+
+def login(client):
+    resp = client.post('/login', json={'username': 'admin', 'password': 'admin'})
+    assert resp.status_code == 200
+
+
+def test_recurrents_summary(client):
+    login(client)
+    resp = client.get('/stats/recurrents/summary?month=2021-05')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['positive'] == pytest.approx(1000)
+    assert data['negative'] == pytest.approx(130)
+    assert data['balance'] == pytest.approx(874)
+    assert data['recurrent'] == pytest.approx(50)


### PR DESCRIPTION
## Summary
- implement `/stats/recurrents/summary` route to provide monthly totals
- add test for the new endpoint
- update frontend recurrent totals to use the new API

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868e99dc594832fa53c629ac6271681