### PR TITLE
Improve recurrent detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ Tresoperso est une application de gestion de trésorerie personnelle. Elle perme
 - Visualisation des transactions récurrentes
 
 La page **Récurrentes** affiche les opérations récurrentes détectées sur les six
-derniers mois. Deux transactions ou plus sont groupées lorsqu'elles partagent le
-même libellé (hors chiffres) et que leurs montants sont compris entre 80&nbsp;% et
-130&nbsp;% de la moyenne du groupe. Les dates au sein d'un groupe ne doivent pas
-varier de plus de sept&nbsp;jours d'un mois à l'autre.
+derniers mois. Les libellés des transactions sont prétraités (suppression des
+chiffres, des espaces et de la ponctuation) puis comparés avec un seuil de
+similarité de 80&nbsp;%. Deux transactions ou plus sont groupées lorsque ce seuil
+est atteint et que leurs montants restent entre 80&nbsp;% et 130&nbsp;% de la
+moyenne du groupe. Les dates au sein d'un groupe ne doivent pas varier de plus
+de sept&nbsp;jours d'un mois à l'autre.
 
 
 ## Lancement rapide

--- a/tests/test_compute_recurrents.py
+++ b/tests/test_compute_recurrents.py
@@ -1,0 +1,62 @@
+import datetime
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+import backend.routes as routes_module
+
+
+def setup_db():
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    routes_module.models.engine = engine
+    routes_module.models.SessionLocal = models.SessionLocal
+    models.init_db()
+    return models.SessionLocal()
+
+
+def test_digits_only_vary(monkeypatch):
+    session = setup_db()
+    cat = models.Category(name='Sub')
+    session.add(cat)
+    session.flush()
+    session.add_all([
+        models.Transaction(date=datetime.date(2021, 1, 5), label='Abo 01', amount=-10, category=cat),
+        models.Transaction(date=datetime.date(2021, 2, 5), label='Abo 02', amount=-11, category=cat),
+        models.Transaction(date=datetime.date(2021, 3, 5), label='Abo 03', amount=-9, category=cat),
+    ])
+    session.commit()
+
+    recs = routes_module.compute_recurrents(
+        session,
+        datetime.date(2021, 1, 1),
+        datetime.date(2021, 4, 1),
+    )
+
+    assert len(recs) == 1
+    assert len(recs[0]['transactions']) == 3
+    session.close()
+
+
+def test_date_in_label(monkeypatch):
+    session = setup_db()
+    cat = models.Category(name='Sub')
+    session.add(cat)
+    session.flush()
+    session.add_all([
+        models.Transaction(date=datetime.date(2021, 1, 10), label='Bill 2021-01-01', amount=-40, category=cat),
+        models.Transaction(date=datetime.date(2021, 2, 10), label='Bill 2021-02-01', amount=-41, category=cat),
+        models.Transaction(date=datetime.date(2021, 3, 10), label='Bill 2021-03-01', amount=-39, category=cat),
+    ])
+    session.commit()
+
+    recs = routes_module.compute_recurrents(
+        session,
+        datetime.date(2021, 1, 1),
+        datetime.date(2021, 4, 1),
+    )
+
+    assert len(recs) == 1
+    assert len(recs[0]['transactions']) == 3
+    session.close()


### PR DESCRIPTION
## Summary
- normalize labels by stripping digits and punctuation
- allow configuring similarity threshold for recurring transactions
- log when no recurring transactions found
- add tests for recurring transaction detection
- update docs about recurrence grouping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68692989383c832f94ec5b478f4fc3b0