### PR TITLE
Improve recurrent detection and UX

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -147,6 +147,12 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
     margin-top: 10px;
 }
 
+#recurrents-no-data {
+    text-align: center;
+    font-style: italic;
+    margin-top: 10px;
+}
+
 #categories-table td {
     text-align: left;
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -193,6 +193,7 @@
                     <canvas id="recurrents-donut"></canvas>
                     <ul id="recurrents-items"></ul>
                 </div>
+                <div id="recurrents-no-data" style="display:none;">Aucune transaction récurrente trouvée.</div>
             </section>
 
             <section id="projection-section" style="display:none;">
@@ -1541,7 +1542,24 @@
             // Fetch recurring transactions
             const resp = await fetch(`/stats/recurrents?month=${month}`);
             if (!resp.ok) return;
-            recurrentsData = await resp.json();
+            const data = await resp.json();
+            const noDataMsg = document.getElementById('recurrents-no-data');
+            const calView = document.getElementById('recurrents-calendar-view');
+            const listView = document.getElementById('recurrents-list-view');
+            if (!Array.isArray(data) || data.length === 0) {
+                recurrentsData = [];
+                if (noDataMsg) {
+                    noDataMsg.textContent = data.message || 'Aucune transaction récurrente trouvée.';
+                    noDataMsg.style.display = 'block';
+                }
+                if (calView) calView.style.display = 'none';
+                if (listView) listView.style.display = 'none';
+                return;
+            }
+            recurrentsData = data;
+            if (noDataMsg) noDataMsg.style.display = 'none';
+            if (calView) calView.style.display = 'flex';
+            if (listView) listView.style.display = 'none';
 
             // Place dots and populate sidebar
             const sidebar = document.getElementById('recurrents-sidebar');
@@ -1880,12 +1898,14 @@
         recurrentsOverlay.addEventListener('click', e => { if (e.target === recurrentsOverlay) recurrentsOverlay.style.display = 'none'; });
         if (recurrentsBtnCalendar && recurrentsBtnList) {
             recurrentsBtnCalendar.addEventListener('click', () => {
+                if (recurrentsData.length === 0) return;
                 recurrentsBtnCalendar.classList.add('selected');
                 recurrentsBtnList.classList.remove('selected');
                 if (recurrentsCalendarView) recurrentsCalendarView.style.display = 'flex';
                 if (recurrentsListView) recurrentsListView.style.display = 'none';
             });
             recurrentsBtnList.addEventListener('click', () => {
+                if (recurrentsData.length === 0) return;
                 recurrentsBtnList.classList.add('selected');
                 recurrentsBtnCalendar.classList.remove('selected');
                 if (recurrentsCalendarView) recurrentsCalendarView.style.display = 'none';


### PR DESCRIPTION
## Summary
- add explicit parameters and logging to `compute_recurrents`
- return friendly message from `/stats/recurrents` when no recurrence found
- show notice on frontend when API returns no recurring transactions
- style empty state for recurring transactions calendar

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869347b0a20832f93e8284a71b5d0f0