### PR TITLE
Add optional secure cookie setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Si ce n'est pas le cas, ouvrez manuellement cette URL.
 Le serveur Flask écoute sur l'adresse `0.0.0.0`, ce qui permet d'exposer
 l'application sur le réseau local.
 
+Par défaut, le cookie de session est marqué comme sécurisé. Pour un
+déploiement local en HTTP simple, définissez la variable d'environnement
+`USE_SECURE_COOKIES=0` avant de lancer `python run.py` afin de désactiver
+l'attribut *secure* du cookie.
+
 ## Environnement de développement
 
 Les dépendances principales (**Flask**, **SQLAlchemy**, **Flask-Login**) ainsi que

--- a/backend/app.py
+++ b/backend/app.py
@@ -20,7 +20,10 @@ app.secret_key = config.SECRET_KEY
 # - SESSION_COOKIE_HTTPONLY prevents JavaScript access to the cookie.
 # - SESSION_COOKIE_SECURE ensures the cookie is only sent over HTTPS.
 app.config['SESSION_COOKIE_HTTPONLY'] = True
-app.config['SESSION_COOKIE_SECURE'] = True
+use_secure_cookies = os.environ.get('USE_SECURE_COOKIES', '1')
+app.config['SESSION_COOKIE_SECURE'] = str(use_secure_cookies).lower() not in (
+    '0', 'false', 'no'
+)
 
 CATEGORIES_JSON = config.CATEGORIES_JSON
 


### PR DESCRIPTION
## Summary
- make secure session cookies configurable via USE_SECURE_COOKIES
- document new variable under the Quick start section

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a34eb7f40832f8f98f1c46d515a39