### PR TITLE
Ensure monthly averages include empty categories

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1012,9 +1012,15 @@ def compute_category_monthly_averages(session, months=12):
             models.Category.name,
             func.sum(models.Transaction.amount),
         )
-        .outerjoin(models.Category, models.Transaction.category_id == models.Category.id)
-        .filter(models.Transaction.date >= start)
-        .filter(models.Transaction.date < current_start)
+        .select_from(models.Category)
+        .outerjoin(
+            models.Transaction,
+            and_(
+                models.Transaction.category_id == models.Category.id,
+                models.Transaction.date >= start,
+                models.Transaction.date < current_start,
+            ),
+        )
         .group_by(models.Category.name)
         .all()
     )


### PR DESCRIPTION
## Summary
- include empty categories when aggregating by starting from the `Category` table
- filter date range in the join itself

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a3664b7a4832fb5dbef2bc09831ff