### PR TITLE
Disable secure cookie by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,8 @@ Si ce n'est pas le cas, ouvrez manuellement cette URL.
 Le serveur Flask écoute sur l'adresse `0.0.0.0`, ce qui permet d'exposer
 l'application sur le réseau local.
 
-Par défaut, le cookie de session est marqué comme sécurisé. Pour un
-déploiement local en HTTP simple, définissez la variable d'environnement
-`USE_SECURE_COOKIES=0` avant de lancer `python run.py` afin de désactiver
-l'attribut *secure* du cookie.
+Le cookie de session n'est plus marqué comme sécurisé par défaut. Il est donc
+accepté même en HTTP simple sans configuration supplémentaire.
 
 ## Environnement de développement
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -20,10 +20,10 @@ app.secret_key = config.SECRET_KEY
 # - SESSION_COOKIE_HTTPONLY prevents JavaScript access to the cookie.
 # - SESSION_COOKIE_SECURE ensures the cookie is only sent over HTTPS.
 app.config['SESSION_COOKIE_HTTPONLY'] = True
-use_secure_cookies = os.environ.get('USE_SECURE_COOKIES', '1')
-app.config['SESSION_COOKIE_SECURE'] = str(use_secure_cookies).lower() not in (
-    '0', 'false', 'no'
-)
+# Disable the "secure" attribute on the session cookie directly.
+# Previously this behavior depended on the USE_SECURE_COOKIES environment
+# variable, which could be inconvenient in a plain HTTP environment.
+app.config['SESSION_COOKIE_SECURE'] = False
 
 CATEGORIES_JSON = config.CATEGORIES_JSON
 


### PR DESCRIPTION
## Summary
- disable secure session cookie directly in backend
- note cookie behavior update in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a401cda50832f83dfd882f0677509