### PR TITLE
UI improvements for recurrent transactions

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -311,14 +311,30 @@ body.hide-amounts .amount-input {
     gap: 10px;
 }
 #recurrents-list-view canvas {
-    flex: 1 1 40%;
-    max-width: 40%;
+    flex: 1 1 38%;
+    max-width: 38%;
 }
-#recurrents-list-view ul {
+#recurrents-list-view table {
     flex: 1 1 60%;
-    list-style: none;
-    padding: 0;
-    margin: 0;
+    border-collapse: collapse;
+    width: 100%;
+}
+#recurrents-table th,
+#recurrents-table td {
+    border: 1px solid var(--border-color);
+    padding: 2px 4px;
+}
+#recurrents-table td:nth-child(2) {
+    font-size: 0.85rem;
+}
+#recurrents-table td:nth-child(3) {
+    text-align: right;
+    white-space: nowrap;
+    min-width: 7em;
+}
+#recurrents-table td:nth-child(4) {
+    white-space: nowrap;
+    min-width: 5em;
 }
 .rec-pastille {
     display: inline-block;
@@ -328,11 +344,7 @@ body.hide-amounts .amount-input {
     margin-right: 4px;
 }
 .rec-item {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 2px 4px;
-    border-bottom: 1px solid var(--border-color);
+    cursor: pointer;
 }
 .sidebar-item {
     cursor: pointer;
@@ -357,17 +369,17 @@ body.hide-amounts .amount-input {
     padding: 2px;
 }
 .rec-dot {
-    width: 8px;
-    height: 8px;
+    width: 16px;
+    height: 16px;
     border-radius: 50%;
     position: absolute;
-    bottom: 2px;
-    right: 2px;
+    bottom: 4px;
+    right: 4px;
 }
-.rec-dot:nth-of-type(2) { bottom: 12px; }
-.rec-dot:nth-of-type(3) { bottom: 22px; }
-.rec-dot:nth-of-type(4) { bottom: 32px; }
-.rec-dot:nth-of-type(5) { bottom: 42px; }
+.rec-dot:nth-of-type(2) { bottom: 24px; }
+.rec-dot:nth-of-type(3) { bottom: 44px; }
+.rec-dot:nth-of-type(4) { bottom: 64px; }
+.rec-dot:nth-of-type(5) { bottom: 84px; }
 
 @media (max-width: 600px) {
     #transactions-table {
@@ -387,7 +399,7 @@ body.hide-amounts .amount-input {
     #recurrents-calendar-view #recurrents-calendar,
     #recurrents-sidebar,
     #recurrents-list-view canvas,
-    #recurrents-list-view ul {
+    #recurrents-list-view table {
         flex-basis: 100%;
         max-width: none;
     }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -191,7 +191,12 @@
                 </div>
                 <div id="recurrents-list-view" style="display:none;">
                     <canvas id="recurrents-donut"></canvas>
-                    <ul id="recurrents-items"></ul>
+                    <table id="recurrents-table">
+                        <thead>
+                            <tr><th></th><th>Libellé</th><th>Montant</th><th>Fréquence</th></tr>
+                        </thead>
+                        <tbody id="recurrents-items"></tbody>
+                    </table>
                 </div>
                 <div id="recurrents-no-data" style="display:none;">Aucune transaction récurrente trouvée selon les critères de similarité ou de montant.</div>
             </section>
@@ -1550,6 +1555,7 @@
                 div.className = 'day';
                 div.textContent = i;
                 div.dataset.day = i;
+                div.addEventListener('mouseenter', () => showSidebarDay(i));
                 container.appendChild(div);
             }
 
@@ -1587,7 +1593,6 @@
                 dot.style.background = rec.category.color || 'gray';
                 dot.title = `${rec.category.name || ''} ${formatAmount(avg)}`;
                 dot.addEventListener('click', () => showRecurrent(rec));
-                dot.addEventListener('mouseover', () => showSidebarDay(rec.day));
                 cell.appendChild(dot);
             });
 
@@ -1643,30 +1648,33 @@
         }
 
         function populateRecurrentsList() {
-            const list = document.getElementById('recurrents-items');
-            if (!list) return;
-            list.innerHTML = '';
+            const tbody = document.getElementById('recurrents-items');
+            if (!tbody) return;
+            tbody.innerHTML = '';
             recurrentsData.forEach(rec => {
-                const li = document.createElement('li');
-                li.className = 'rec-item';
+                const tr = document.createElement('tr');
+                tr.className = 'rec-item';
+                const dotTd = document.createElement('td');
                 const dot = document.createElement('span');
                 dot.className = 'rec-pastille';
                 dot.style.background = rec.category.color || 'gray';
-                li.appendChild(dot);
-                const lbl = document.createElement('span');
-                lbl.textContent = rec.transactions[0].label;
-                li.appendChild(lbl);
+                dotTd.appendChild(dot);
+                tr.appendChild(dotTd);
+                const lblTd = document.createElement('td');
+                lblTd.className = 'label';
+                lblTd.textContent = rec.transactions[0].label;
+                tr.appendChild(lblTd);
                 const avg = rec.transactions.reduce((s,t)=>s+t.amount,0)/rec.transactions.length;
-                const amt = document.createElement('span');
-                amt.className = 'amount';
-                amt.textContent = formatAmount(avg);
-                li.appendChild(amt);
-                const freq = document.createElement('span');
-                freq.className = 'frequency';
-                freq.textContent = guessFrequency(rec.transactions);
-                li.appendChild(freq);
-                li.addEventListener('click', () => showRecurrent(rec));
-                list.appendChild(li);
+                const amtTd = document.createElement('td');
+                amtTd.className = 'amount';
+                amtTd.textContent = formatAmount(avg);
+                tr.appendChild(amtTd);
+                const freqTd = document.createElement('td');
+                freqTd.className = 'frequency';
+                freqTd.textContent = guessFrequency(rec.transactions);
+                tr.appendChild(freqTd);
+                tr.addEventListener('click', () => showRecurrent(rec));
+                tbody.appendChild(tr);
             });
         }
 


### PR DESCRIPTION
## Summary
- show recurrent transactions in a table
- adjust donut chart width
- enlarge calendar dots and show sidebar on cell hover
- tweak styles for readability

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686a81b09698832f948291b853f8862f