### PR TITLE
Add styles for income and expense tables

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -24,6 +24,16 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
 .thin-grid td {
     border: 1px solid var(--border-color);
 }
+#income-table,
+#expense-table {
+    border-collapse: collapse;
+}
+#income-table th,
+#income-table td,
+#expense-table th,
+#expense-table td {
+    border: 1px solid var(--border-color);
+}
 #transactions-table {
     font-size: 0.85rem;
     width: 95%;


### PR DESCRIPTION
## Summary
- style `#income-table` and `#expense-table` to match other tables

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: test_category_average_helper.py, test_category_forecast_helper.py, test_dashboard.py, test_dashboard_helper.py, test_projection_categories.py, test_projection_categories_average_endpoint.py, test_projection_categories_forecast_endpoint.py, test_projection_category_average.py, test_projection_category_forecast.py)*

------
https://chatgpt.com/codex/tasks/task_e_686a93891c3c832f9eeb8e490c44d2b7