### PR TITLE
Update recurrent summary computation

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -839,8 +839,10 @@ def stats_recurrents_summary():
         or 0
     )
 
-    rec_start = _shift_month(current_first, -5)
-    recs = compute_recurrents(session, rec_start, end)
+    rec_ref = datetime.now().date().replace(day=1)
+    rec_start = _shift_month(rec_ref, -5)
+    rec_end = _shift_month(rec_ref, 1) - timedelta(days=1)
+    recs = compute_recurrents(session, rec_start, rec_end)
     recurrent_total = sum(
         abs(r['average_amount']) for r in recs if r['average_amount'] < 0
     )

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1668,7 +1668,7 @@
             if (btnIn) btnIn.textContent = `Entrées\n${hide ? '•••' : formatAmount(data.positive)}`;
             if (btnOut) btnOut.textContent = `Sorties\n${hide ? '•••' : formatAmount(data.negative)}`;
             if (btnBal) btnBal.textContent = `Solde\n${hide ? '•••' : formatAmount(data.balance)}`;
-            if (btnRec) btnRec.textContent = `Flux de trésorerie\n${hide ? '•••' : formatAmount(data.recurrent)}`;
+            if (btnRec) btnRec.textContent = `Récurrents\n${hide ? '•••' : formatAmount(data.recurrent)}`;
         }
 
         async function fetchMonthlyCategories(month) {

--- a/tests/test_category_average_helper.py
+++ b/tests/test_category_average_helper.py
@@ -18,6 +18,7 @@ def setup_db(monkeypatch):
     models.SessionLocal = sessionmaker(bind=engine)
     app_module.SessionLocal = models.SessionLocal
     monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    monkeypatch.setattr(app_module.routes, 'datetime', FixedDate)
     models.init_db()
     return models.SessionLocal()
 

--- a/tests/test_category_forecast_helper.py
+++ b/tests/test_category_forecast_helper.py
@@ -18,6 +18,7 @@ def setup_db(monkeypatch):
     models.SessionLocal = sessionmaker(bind=engine)
     app_module.SessionLocal = models.SessionLocal
     monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    monkeypatch.setattr(app_module.routes, 'datetime', FixedDate)
     models.init_db()
     return models.SessionLocal()
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -18,6 +18,7 @@ def client(monkeypatch):
     models.SessionLocal = sessionmaker(bind=engine)
     app_module.SessionLocal = models.SessionLocal
     monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    monkeypatch.setattr(app_module.routes, 'datetime', FixedDate)
     models.init_db()
     session = models.SessionLocal()
     cat = models.Category(name='Food', favorite=True)

--- a/tests/test_dashboard_helper.py
+++ b/tests/test_dashboard_helper.py
@@ -18,6 +18,7 @@ def setup_db(monkeypatch):
     models.SessionLocal = sessionmaker(bind=engine)
     app_module.SessionLocal = models.SessionLocal
     monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    monkeypatch.setattr(app_module.routes, 'datetime', FixedDate)
     models.init_db()
     return models.SessionLocal()
 

--- a/tests/test_favorite_filters.py
+++ b/tests/test_favorite_filters.py
@@ -20,6 +20,7 @@ def client(monkeypatch):
     models.SessionLocal = sessionmaker(bind=engine)
     app_module.SessionLocal = models.SessionLocal
     monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    monkeypatch.setattr(app_module.routes, 'datetime', FixedDate)
     models.init_db()
     session = models.SessionLocal()
     cat = models.Category(name='Cat')

--- a/tests/test_projection_categories.py
+++ b/tests/test_projection_categories.py
@@ -18,6 +18,7 @@ def client(monkeypatch):
     models.SessionLocal = sessionmaker(bind=engine)
     app_module.SessionLocal = models.SessionLocal
     monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    monkeypatch.setattr(app_module.routes, 'datetime', FixedDate)
     models.init_db()
     session = models.SessionLocal()
     food = models.Category(name='Food')

--- a/tests/test_projection_categories_average_endpoint.py
+++ b/tests/test_projection_categories_average_endpoint.py
@@ -20,6 +20,7 @@ def client(monkeypatch):
     models.SessionLocal = sessionmaker(bind=engine)
     app_module.SessionLocal = models.SessionLocal
     monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    monkeypatch.setattr(app_module.routes, 'datetime', FixedDate)
     models.init_db()
     session = models.SessionLocal()
     food = models.Category(name='Food')

--- a/tests/test_projection_categories_forecast_endpoint.py
+++ b/tests/test_projection_categories_forecast_endpoint.py
@@ -20,6 +20,7 @@ def client(monkeypatch):
     models.SessionLocal = sessionmaker(bind=engine)
     app_module.SessionLocal = models.SessionLocal
     monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    monkeypatch.setattr(app_module.routes, 'datetime', FixedDate)
     models.init_db()
     session = models.SessionLocal()
     food = models.Category(name='Food')

--- a/tests/test_projection_category_average.py
+++ b/tests/test_projection_category_average.py
@@ -18,6 +18,7 @@ def client(monkeypatch):
     models.SessionLocal = sessionmaker(bind=engine)
     app_module.SessionLocal = models.SessionLocal
     monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    monkeypatch.setattr(app_module.routes, 'datetime', FixedDate)
     models.init_db()
     session = models.SessionLocal()
     food = models.Category(name='Food')

--- a/tests/test_projection_category_forecast.py
+++ b/tests/test_projection_category_forecast.py
@@ -19,6 +19,7 @@ def client(monkeypatch):
     models.SessionLocal = sessionmaker(bind=engine)
     app_module.SessionLocal = models.SessionLocal
     monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    monkeypatch.setattr(app_module.routes, 'datetime', FixedDate)
     models.init_db()
     session = models.SessionLocal()
     food = models.Category(name='Food')

--- a/tests/test_recurrents_categories.py
+++ b/tests/test_recurrents_categories.py
@@ -18,6 +18,7 @@ def client(monkeypatch):
     models.SessionLocal = sessionmaker(bind=engine)
     app_module.SessionLocal = models.SessionLocal
     monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    monkeypatch.setattr(app_module.routes, 'datetime', FixedDate)
     models.init_db()
     session = models.SessionLocal()
     cat1 = models.Category(name='Sub1', color='red')

--- a/tests/test_recurrents_endpoint.py
+++ b/tests/test_recurrents_endpoint.py
@@ -18,6 +18,7 @@ def client(monkeypatch):
     models.SessionLocal = sessionmaker(bind=engine)
     app_module.SessionLocal = models.SessionLocal
     monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    monkeypatch.setattr(app_module.routes, 'datetime', FixedDate)
     models.init_db()
     session = models.SessionLocal()
     cat = models.Category(name='Sub', color='red')

--- a/tests/test_recurrents_summary.py
+++ b/tests/test_recurrents_summary.py
@@ -6,6 +6,11 @@ from sqlalchemy.orm import sessionmaker
 from backend import models
 import backend as app_module
 
+class FixedDate(datetime.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2021, 5, 15)
+
 
 @pytest.fixture
 def client(monkeypatch):
@@ -13,7 +18,8 @@ def client(monkeypatch):
     models.engine = engine
     models.SessionLocal = sessionmaker(bind=engine)
     app_module.SessionLocal = models.SessionLocal
-    monkeypatch.setattr(app_module, 'datetime', datetime.datetime)
+    monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    monkeypatch.setattr(app_module.routes, 'datetime', FixedDate)
     models.init_db()
     session = models.SessionLocal()
     acc = models.BankAccount(name='Main', initial_balance=200)

--- a/tests/test_stats_endpoint.py
+++ b/tests/test_stats_endpoint.py
@@ -20,6 +20,7 @@ def client(monkeypatch):
     models.SessionLocal = sessionmaker(bind=engine)
     app_module.SessionLocal = models.SessionLocal
     monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    monkeypatch.setattr(app_module.routes, 'datetime', FixedDate)
     models.init_db()
     session = models.SessionLocal()
     session.add_all([

--- a/tests/test_stats_period_filters.py
+++ b/tests/test_stats_period_filters.py
@@ -22,6 +22,7 @@ def client(monkeypatch):
     models.SessionLocal = sessionmaker(bind=engine)
     app_module.SessionLocal = models.SessionLocal
     monkeypatch.setattr(app_module, 'datetime', FixedDate)
+    monkeypatch.setattr(app_module.routes, 'datetime', FixedDate)
     models.init_db()
     session = models.SessionLocal()
     session.add_all([


### PR DESCRIPTION
## Summary
- compute recurrent totals independent of month filter
- rename recurrent button label in frontend
- adjust tests to patch backend.routes.datetime

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a9e80486c832fab19fce89269b15d