### PR TITLE
Add Tresoperso logo in navbar

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -231,6 +231,7 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
 #app { display: flex; flex-direction: column; }
 #navbar { position: fixed; top: 0; left: 0; right: 0; border-bottom: 1px solid var(--border-color); background: var(--bg-color); z-index: 1000; }
 #navbar ul { list-style: none; margin: 0; padding: 0; display: flex; }
+#navbar .logo { font-weight: bold; color: #fc9107; padding: 4px 8px; }
 #navbar li { position: relative; margin-right: 20px; }
 #navbar .menu-header {
     cursor: pointer;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,6 +18,7 @@
     <div id="app" style="display:none;">
         <nav id="navbar">
             <ul class="menu">
+                <li class="logo">Tresoperso</li>
                 <li class="open">
                     <div class="menu-header">Transactions</div>
                     <ul class="submenu">
@@ -43,7 +44,6 @@
             </ul>
         </nav>
         <div id="content">
-            <h1>Tresoperso</h1>
             <section id="dashboard-section" style="display:none;">
                 <h2>Dashboard</h2>
                 <label for="dashboard-threshold">Seuil exceptionnel&nbsp;:</label>


### PR DESCRIPTION
## Summary
- insert logo item in the navigation menu
- remove redundant H1 title from content area
- style `.logo` for orange text in the navbar

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bdfe02058832faeebc4f07fad3ed8