### PR TITLE
Enable hover-based nav submenus

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -238,6 +238,12 @@ th, td { border: 1px solid var(--border-color); padding: 4px; }
     font-weight: bold;
     padding: 4px 8px;
     border: none;
+    transition: background-color 0.2s, color 0.2s;
+}
+#navbar li.open > .menu-header,
+#navbar li > .menu-header:hover {
+    color: #fc9107;
+    background-color: var(--bg-color);
 }
 #navbar .submenu { list-style: none; padding: 0; position: absolute; top: 100%; left: 0; background: var(--bg-color); border: 1px solid var(--border-color); display: none; }
 #navbar li.open > .submenu { display: block; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2399,9 +2399,17 @@
             sidebarButtons[0].classList.add('selected');
         }
 
-        document.querySelectorAll('#navbar .menu-header').forEach(header => {
-            header.addEventListener('click', () => {
-                header.parentElement.classList.toggle('open');
+        document.querySelectorAll('#navbar li').forEach(li => {
+            const header = li.querySelector('.menu-header');
+            if (!header) return;
+            header.addEventListener('mouseenter', () => {
+                document.querySelectorAll('#navbar li.open').forEach(openLi => {
+                    if (openLi !== li) openLi.classList.remove('open');
+                });
+                li.classList.add('open');
+            });
+            li.addEventListener('mouseleave', () => {
+                li.classList.remove('open');
             });
         });
 


### PR DESCRIPTION
## Summary
- open nav submenus on hover instead of click
- highlight menu headers on hover/open

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be0c38094832fac9e2f3ab13b73d9