### PR TITLE
Unify subheadings for tables and charts

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -24,6 +24,13 @@ h1 {
     font-size: 1.8em;
 }
 
+.section-title {
+    color: var(--interactive-color);
+    font-weight: bold;
+    font-size: 1.2em;
+    margin: 1em 0 0.2em 0;
+}
+
 table { border-collapse: collapse; width: 100%; }
 th, td { border: 1px solid var(--border-color); padding: 4px; }
 .thin-grid th,
@@ -481,17 +488,6 @@ body.hide-amounts .amount-input {
 }
 
 /* Projection styles */
-#projection-section > h2 {
-    font-size: 1.6em;
-    color: var(--interactive-color);
-    margin-bottom: 0.5em;
-}
-
-#projection-section h3 {
-    font-size: 1.2em;
-    color: var(--interactive-color);
-    margin: 1em 0 0.2em 0;
-}
 
 #projection-cat-table,
 #projection-future-table {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -217,13 +217,13 @@
 
             <section id="projection-section" style="display:none;">
                 <h1>Projection</h1>
-                <h3>Dépenses passées</h3>
+                <h2 class="section-title">Dépenses passées</h2>
                 <p id="projection-cat-period"></p>
                 <table id="projection-cat-table">
                     <thead></thead>
                     <tbody></tbody>
                 </table>
-                <h3>Prévisions</h3>
+                <h2 class="section-title">Prévisions</h2>
                 <p id="projection-future-period"></p>
                 <div id="projection-mode">
                     <label><input type="radio" name="projection-mode" value="average" checked> valeurs moyennes</label>
@@ -251,7 +251,7 @@
                         </table>
                     </div>
                     <div class="settings-col">
-                        <h3>Sous-catégories</h3>
+                        <h2 class="section-title">Sous-catégories</h2>
                         <form id="subcategory-form">
                             <input type="hidden" id="subcategory-id" />
                             <input type="text" id="subcategory-name" placeholder="Nom" required />


### PR DESCRIPTION
## Summary
- style `.section-title` for blue subheadings
- use section titles in projection and settings pages
- remove old projection heading rules

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be4ec1c30832f9090a9922a09fd33