### PR TITLE
Add themed styles for table headers

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -10,6 +10,7 @@
     --popup-bg: #fff;
     --interactive-color: #0066cc;
     --selected-color: #cce5ff;
+    --table-header-bg: var(--selected-color);
 }
 
 body {
@@ -33,6 +34,11 @@ h1 {
 
 table { border-collapse: collapse; width: 100%; border: none; }
 th, td { border: 1px solid #808080; padding: 4px; }
+thead th,
+tbody th {
+    background: var(--table-header-bg);
+    color: var(--bg-color);
+}
 .thin-grid th,
 .thin-grid td {
     border: 1px solid var(--border-color);

--- a/frontend/dark.css
+++ b/frontend/dark.css
@@ -5,5 +5,6 @@
     --popup-bg: #2a2a2a;
     --interactive-color: #66c2ff;
     --selected-color: #fc9107;
+    --table-header-bg: var(--selected-color);
 }
 

--- a/frontend/light.css
+++ b/frontend/light.css
@@ -5,4 +5,5 @@
     --popup-bg: #ffffff;
     --interactive-color: #003366;
     --selected-color: #003366;
+    --table-header-bg: #cce5ff;
 }


### PR DESCRIPTION
## Summary
- define `--table-header-bg` CSS variable for table header colors
- color `<thead>` and `<tbody>` header cells using the variable
- style dark and light themes with appropriate header colors

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bf83e757c832f9be13e49cf56cabc