### PR TITLE
Ensure projection details match main table filters

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1745,6 +1745,7 @@
                 sort_by: 'date',
                 order: 'asc'
             });
+            params.append('to_analyze', 'true');
             if (cat) {
                 params.append('category_id', cat.id);
             } else if (normalizeName(catName) === normalizeName('Inconnu')) {


### PR DESCRIPTION
## Summary
- filter projection popup to only fetch transactions marked for analysis

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686cc98195d0832f8eb4611349b8d6a0