### PR TITLE
Fix projection tables after analysis toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1002,6 +1002,7 @@
                 analyzeBox.addEventListener('change', async () => {
                     await fetch('/transactions/' + t.id, {method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({to_analyze: analyzeBox.checked})});
                     fetchTransactions();
+                    fetchProjectionCategories();
                 });
                 analyzeCell.appendChild(analyzeBox);
                 tr.appendChild(analyzeCell);
@@ -2575,6 +2576,7 @@
                 });
             }));
             fetchTransactions();
+            fetchProjectionCategories();
         }
 
         document.getElementById('toggle-all-reconciled').addEventListener('click', toggleReconciledAll);


### PR DESCRIPTION
## Summary
- ensure projection tables refresh when toggling "À analyser" status

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc8ea7ef4832f83c8062c2d479b30