### PR TITLE
Add favorites-only filter to dashboard

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -50,6 +50,7 @@
                 <input type="number" id="dashboard-threshold" step="0.1" value="1.5" style="width:4em;" />
                 <label for="dashboard-months" style="margin-left:1em;">Nombre de mois de référence&nbsp;:</label>
                 <input type="number" id="dashboard-months" step="1" min="1" value="3" style="width:3em;" />
+                <label style="margin-left:1em;"><input type="checkbox" id="dashboard-favorites-only" /> Analyser uniquement les transactions favorites</label>
                 <div id="dashboard-content">Chargement...</div>
                 <canvas id="dashboardChart" width="400" height="200"></canvas>
             </section>
@@ -1443,12 +1444,16 @@
             if (dashboardMonthsInput) {
                 months = parseInt(dashboardMonthsInput.value) || 3;
             }
-            const params = new URLSearchParams({ threshold, months });
+            const favOnly = dashboardFavOnlyInput && dashboardFavOnlyInput.checked;
+            const params = new URLSearchParams({ threshold, months, favorites_only: favOnly });
             const resp = await fetch('/dashboard?' + params.toString());
             if (handleUnauthorized(resp) || !resp.ok) return;
             const data = await resp.json();
             const container = document.getElementById('dashboard-content');
             container.innerHTML = `<p>Favoris: ${data.favorite_count} | Total 30j: ${formatAmount(data.recent_total)} | Solde: ${formatAmount(data.balance_total)}</p>`;
+            const modeP = document.createElement('p');
+            modeP.textContent = data.favorites_only ? 'Filtre\u202f: Favorites uniquement' : 'Filtre\u202f: Toutes les transactions';
+            container.appendChild(modeP);
             if (data.alerts && data.alerts.length) {
                 const table = document.createElement('table');
                 table.innerHTML = '<thead><tr><th>Date</th><th>Libellé</th><th>Montant</th><th>Catégorie</th><th>Raison</th></tr></thead><tbody></tbody>';
@@ -2454,6 +2459,7 @@
         const projectionModeInputs = document.querySelectorAll('#projection-mode input');
         const dashboardThresholdInput = document.getElementById('dashboard-threshold');
         const dashboardMonthsInput = document.getElementById('dashboard-months');
+        const dashboardFavOnlyInput = document.getElementById('dashboard-favorites-only');
         const recurrentMonthInput = document.getElementById('recurrent-month');
 
         function applyPreferences() {
@@ -2462,6 +2468,7 @@
             const hide = localStorage.getItem('hideAmounts') === 'true';
             const threshold = localStorage.getItem('dashboardThreshold') || '1.5';
             const months = localStorage.getItem('dashboardMonths') || '3';
+            const favOnly = localStorage.getItem('dashboardFavoritesOnly') === 'true';
             themeLink.href = theme + '.css';
             document.body.classList.remove('font-roboto', 'font-arial', 'font-geneva');
             document.body.classList.add('font-' + font);
@@ -2471,6 +2478,7 @@
             hideAmountsBox.checked = hide;
             if (dashboardThresholdInput) dashboardThresholdInput.value = threshold;
             if (dashboardMonthsInput) dashboardMonthsInput.value = months;
+            if (dashboardFavOnlyInput) dashboardFavOnlyInput.checked = favOnly;
         }
 
         themeSelect.addEventListener('change', () => {
@@ -2503,6 +2511,13 @@
         if (dashboardMonthsInput) {
             dashboardMonthsInput.addEventListener('change', () => {
                 localStorage.setItem('dashboardMonths', dashboardMonthsInput.value);
+                fetchDashboard();
+            });
+        }
+
+        if (dashboardFavOnlyInput) {
+            dashboardFavOnlyInput.addEventListener('change', () => {
+                localStorage.setItem('dashboardFavoritesOnly', dashboardFavOnlyInput.checked);
                 fetchDashboard();
             });
         }


### PR DESCRIPTION
## Summary
- add a checkbox to filter dashboard data on favorites
- persist new preference in localStorage
- display the current filter mode when loading dashboard data
- re-fetch dashboard when option changes

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e781ee040832fa12058f0d9a8727e