### PR TITLE
Refine dashboard alerts using category averages

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1166,16 +1166,22 @@ def dashboard():
     recent_txs = recent_query.all()
     for tx in recent_txs:
         name = tx.category.name if tx.category else "Inconnu"
-        if abs(tx.amount) > income_avg:
-            alerts.append(
-                {
-                    "date": tx.date.isoformat(),
-                    "label": tx.label,
-                    "amount": tx.amount,
-                    "category": name,
-                    "reason": "income_threshold",
-                }
-            )
+        cat_avg = cat_avgs.get(tx.category_id)
+        if cat_avg and abs(tx.amount) > cat_avg * threshold:
+            reason = "category_threshold"
+        elif abs(tx.amount) > income_avg:
+            reason = "income_threshold"
+        else:
+            continue
+        alerts.append(
+            {
+                "date": tx.date.isoformat(),
+                "label": tx.label,
+                "amount": tx.amount,
+                "category": name,
+                "reason": reason,
+            }
+        )
 
     current_start = datetime.now().date().replace(day=1)
     groups = {}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -56,6 +56,8 @@ def test_dashboard_alerts_and_summaries(client):
     first = data['alerts'][0]
     for key in ['date', 'label', 'amount', 'category', 'reason']:
         assert key in first
+    huge = [a for a in data['alerts'] if a['label'] == 'Huge expense'][0]
+    assert huge['reason'] == 'category_threshold'
     favs = {}
     cats = {grp['category']: grp for grp in data['favorite_summaries']}
     for grp in data['favorite_summaries']:


### PR DESCRIPTION
## Summary
- use category-based thresholds when generating dashboard alerts
- expect default dashboard alerts to come from `category_threshold`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e8fdf22ac832fa11300b7101c786e