### PR TITLE
Force number formatting after projection table resets

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -556,7 +556,8 @@
             if (localStorage.getItem('hideAmounts') === 'true') {
                 return '•••';
             }
-            return (v || 0)
+            const num = typeof v === 'string' ? parseFloat(v) : v;
+            return (num || 0)
                 .toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})
                 .replace(/,/g, ' ');
         }


### PR DESCRIPTION
## Summary
- ensure `formatAmount` converts string values to numbers before formatting

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68712a7cad54832fb25ea7efe037e0d4