### PR TITLE
Adjust projection reset UI

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -529,6 +529,7 @@ body.hide-amounts .amount-input {
 
 #projection-reset-controls {
     margin: 0.5em 0;
+    font-size: 1.1em;
 }
 
 .reset-cell {
@@ -538,8 +539,12 @@ body.hide-amounts .amount-input {
     font-size: 0.9em;
 }
 
+.reset-label {
+    margin-right: 0.5em;
+}
+
 .editable-cell { position: relative; }
-.editable-cell .reset-cell { position: absolute; right: 2px; top: 2px; }
+.editable-cell .reset-cell { position: absolute; left: 2px; bottom: 2px; }
 .editable-cell .cell-value { display: inline-block; min-width: 4em; }
 
 /* Income/expense background helpers */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -237,6 +237,7 @@
                     <tbody></tbody>
                 </table>
                 <div id="projection-reset-controls">
+                    <span class="reset-label">Rechargement des valeurs calculées&nbsp;:</span>
                     <button id="reset-future-row">↺ Ligne</button>
                     <button id="reset-future-column">↺ Colonne</button>
                     <button id="reset-future-table">↺ Tableau</button>


### PR DESCRIPTION
## Summary
- add label before projection reset controls and enlarge font
- move cell reset icon to bottom left

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713b08ebc0832f8220f2eddbf36182