### PR TITLE
Add unassigned transactions count endpoint

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -570,6 +570,18 @@ def delete_unassigned_transactions():
     return jsonify({'deleted': count})
 
 
+@app.route('/transactions/unassigned/count')
+@login_required
+def count_unassigned_transactions():
+    """Return the number of transactions without an associated bank account."""
+    session = models.SessionLocal()
+    count = session.query(func.count(models.Transaction.id)).filter(
+        models.Transaction.bank_account_id.is_(None)
+    ).scalar() or 0
+    session.close()
+    return jsonify({'count': count})
+
+
 @app.route('/stats')
 @login_required
 def stats():

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -671,7 +671,7 @@
             }
         }
 
-        function populateAccountsTable() {
+        async function populateAccountsTable() {
             const tbody = document.querySelector('#accounts-table tbody');
             if (!tbody) return;
             tbody.innerHTML = '';
@@ -706,30 +706,36 @@
                 tbody.appendChild(tr);
             });
 
-            const noneTr = document.createElement('tr');
-            const noneInfo = document.createElement('td');
-            noneInfo.textContent = 'Pas de référence de compte';
-            noneTr.appendChild(noneInfo);
+            const resp = await fetch('/transactions/unassigned/count');
+            if (!handleUnauthorized(resp) && resp.ok) {
+                const data = await resp.json();
+                if (data.count) {
+                    const noneTr = document.createElement('tr');
+                    const noneInfo = document.createElement('td');
+                    noneInfo.textContent = 'Pas de référence de compte';
+                    noneTr.appendChild(noneInfo);
 
-            const noneAction = document.createElement('td');
-            const noneUpd = document.createElement('button');
-            noneUpd.textContent = 'Mettre à jour';
-            noneUpd.onclick = () => {
-                selectedAccountId = 'none';
-                updateAccountDropdown();
-                displayAccountInfo();
-                fetchBalanceInfo();
-            };
-            const noneDel = document.createElement('button');
-            noneDel.textContent = 'Supprimer';
-            noneDel.onclick = async () => {
-                if (!confirm('Supprimer ces transactions ?')) return;
-                await deleteUnassignedTransactions();
-            };
-            noneAction.appendChild(noneUpd);
-            noneAction.append(' ', noneDel);
-            noneTr.appendChild(noneAction);
-            tbody.appendChild(noneTr);
+                    const noneAction = document.createElement('td');
+                    const noneUpd = document.createElement('button');
+                    noneUpd.textContent = 'Mettre à jour';
+                    noneUpd.onclick = () => {
+                        selectedAccountId = 'none';
+                        updateAccountDropdown();
+                        displayAccountInfo();
+                        fetchBalanceInfo();
+                    };
+                    const noneDel = document.createElement('button');
+                    noneDel.textContent = 'Supprimer';
+                    noneDel.onclick = async () => {
+                        if (!confirm('Supprimer ces transactions ?')) return;
+                        await deleteUnassignedTransactions();
+                    };
+                    noneAction.appendChild(noneUpd);
+                    noneAction.append(' ', noneDel);
+                    noneTr.appendChild(noneAction);
+                    tbody.appendChild(noneTr);
+                }
+            }
             adjustLabelColumns();
         }
 
@@ -753,7 +759,7 @@
             if (handleUnauthorized(resp) || !resp.ok) return;
             accountsData = await resp.json();
             updateAccountDropdown();
-            populateAccountsTable();
+            await populateAccountsTable();
         }
 
         async function createAccount(file) {

--- a/tests/test_unassigned_count_endpoint.py
+++ b/tests/test_unassigned_count_endpoint.py
@@ -1,0 +1,46 @@
+import datetime
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+import backend as app_module
+
+
+@pytest.fixture
+def client():
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    models.init_db()
+    session = models.SessionLocal()
+    session.add_all([
+        models.Transaction(date=datetime.date(2021, 1, 1), label='T1', amount=10),
+        models.Transaction(date=datetime.date(2021, 1, 2), label='T2', amount=20)
+    ])
+    session.commit()
+    session.close()
+    with app_module.app.test_client() as client:
+        yield client
+
+
+def login(client):
+    resp = client.post('/login', json={'username': 'admin', 'password': 'admin'})
+    assert resp.status_code == 200
+
+
+def test_unassigned_count_endpoint(client):
+    login(client)
+    session = models.SessionLocal()
+    acc = models.BankAccount(account_type='Compte', number='123')
+    session.add(acc)
+    session.flush()
+    session.add(models.Transaction(date=datetime.date(2021, 1, 3), label='T3', amount=5, bank_account_id=acc.id))
+    session.commit()
+    session.close()
+
+    resp = client.get('/transactions/unassigned/count')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['count'] == 2


### PR DESCRIPTION
## Summary
- create `/transactions/unassigned/count` endpoint in backend
- update frontend accounts table to call the new endpoint and only display the _Pas de référence de compte_ row when needed
- add unit test for the new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871773cad40832f872f5cc74f131d10