### PR TITLE
Implement account filtering and UI tweaks for cash flow analysis

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -570,3 +570,12 @@ body.hide-amounts .amount-input {
     display: block;
     margin-bottom: 0.25em;
 }
+
+#recurrents-accounts label {
+    display: block;
+    margin-bottom: 0.25em;
+}
+
+#recurrent-month-container {
+    margin-bottom: 0.5em;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -180,6 +180,10 @@
 
             <section id="recurrents-section" style="display:none;">
                 <h1>Flux de trésorerie</h1>
+                <div id="recurrents-accounts"></div>
+                <div id="recurrent-month-container">
+                    <input type="month" id="recurrent-month">
+                </div>
                 <div id="recurrents-header">
                     <button id="btn-recurrent" class="selected"></button>
                     <button id="btn-income"></button>
@@ -187,7 +191,6 @@
                     <button id="btn-balance"></button>
                 </div>
                 <div id="recurrents-controls">
-                    <input type="month" id="recurrent-month">
                     <button id="recurrents-btn-calendar" class="selected">Calendrier</button>
                     <button id="recurrents-btn-list">Liste/anneau</button>
                 </div>
@@ -403,6 +406,7 @@
         let selectedAccountId = '';
         let recurrentsData = [];
         let recurrentsChart = null;
+        let recurrentsAccountIds = [];
         let projectionData = [];
         let projectionFutureTotals = [];
         let projectionFutureMonths = [];
@@ -685,6 +689,27 @@
             });
         }
 
+        function populateRecurrentsAccounts() {
+            const container = document.getElementById('recurrents-accounts');
+            if (!container) return;
+            container.innerHTML = '';
+            accountsData.forEach(a => {
+                const lbl = document.createElement('label');
+                const cb = document.createElement('input');
+                cb.type = 'checkbox';
+                cb.value = a.id;
+                cb.checked = !recurrentsAccountIds.length || recurrentsAccountIds.includes(String(a.id));
+                cb.addEventListener('change', () => {
+                    recurrentsAccountIds = Array.from(container.querySelectorAll('input:checked')).map(c => c.value);
+                    fetchRecurrents();
+                    updateRecurrentsTotals();
+                });
+                lbl.appendChild(cb);
+                lbl.append(' ' + `${a.account_type} ${a.number}`.trim());
+                container.appendChild(lbl);
+            });
+        }
+
         function displayAccountInfo() {
             const info = document.getElementById('account-info');
             const acc = accountsData.find(a => String(a.id) === String(selectedAccountId));
@@ -787,6 +812,7 @@
             accountsData = await resp.json();
             updateAccountDropdown();
             populateProjectionAccounts();
+            populateRecurrentsAccounts();
             await populateAccountsTable();
         }
 
@@ -2022,7 +2048,9 @@
             }
 
             // Fetch recurring transactions
-            const resp = await fetch(`/stats/recurrents?month=${month}`);
+            const params = new URLSearchParams({ month });
+            if (recurrentsAccountIds.length) params.set('account_ids', recurrentsAccountIds.join(','));
+            const resp = await fetch(`/stats/recurrents?${params.toString()}`);
             if (handleUnauthorized(resp) || !resp.ok) return;
             const data = await resp.json();
             const noDataMsg = document.getElementById('recurrents-no-data');
@@ -2137,7 +2165,9 @@
                 month = now.toISOString().slice(0,7);
                 if (monthInput) monthInput.value = month;
             }
-            const resp = await fetch(`/stats/recurrents/summary?month=${month}`);
+            const params = new URLSearchParams({ month });
+            if (recurrentsAccountIds.length) params.set('account_ids', recurrentsAccountIds.join(','));
+            const resp = await fetch(`/stats/recurrents/summary?${params.toString()}`);
             if (handleUnauthorized(resp) || !resp.ok) return;
             const data = await resp.json();
             const hide = localStorage.getItem('hideAmounts') === 'true';

--- a/tests/test_recurrents_summary.py
+++ b/tests/test_recurrents_summary.py
@@ -22,25 +22,29 @@ def client(monkeypatch):
     monkeypatch.setattr(app_module.routes, 'datetime', FixedDate)
     models.init_db()
     session = models.SessionLocal()
-    acc = models.BankAccount(name='Main', initial_balance=200)
+    acc1 = models.BankAccount(name='Main', initial_balance=200)
+    acc2 = models.BankAccount(name='Second', initial_balance=50)
     cat = models.Category(name='Sub', color='red')
-    session.add_all([acc, cat])
+    session.add_all([acc1, acc2, cat])
     session.flush()
     session.add_all([
-        models.Transaction(date=datetime.date(2020,12,5), label='Abo 01', amount=-50, category=cat, account=acc),
-        models.Transaction(date=datetime.date(2021,1,5), label='Abo 02', amount=-52, category=cat, account=acc),
-        models.Transaction(date=datetime.date(2021,2,5), label='Abo 03', amount=-48, category=cat, account=acc),
-        models.Transaction(date=datetime.date(2021,1,1), label='Club 01', amount=-20, category=cat, account=acc),
-        models.Transaction(date=datetime.date(2021,2,25), label='Club 02', amount=-21, category=cat, account=acc),
-        models.Transaction(date=datetime.date(2021,1,20), label='Unique 01', amount=-5, category=cat, account=acc),
-        models.Transaction(date=datetime.date(2021,5,10), label='Salary', amount=1000, account=acc),
-        models.Transaction(date=datetime.date(2021,5,15), label='Groceries', amount=-100, category=cat, account=acc),
-        models.Transaction(date=datetime.date(2021,5,20), label='Stuff', amount=-30, category=cat, account=acc),
+        models.Transaction(date=datetime.date(2020,12,5), label='Abo 01', amount=-50, category=cat, account=acc1),
+        models.Transaction(date=datetime.date(2021,1,5), label='Abo 02', amount=-52, category=cat, account=acc1),
+        models.Transaction(date=datetime.date(2021,2,5), label='Abo 03', amount=-48, category=cat, account=acc1),
+        models.Transaction(date=datetime.date(2021,1,1), label='Club 01', amount=-20, category=cat, account=acc1),
+        models.Transaction(date=datetime.date(2021,2,25), label='Club 02', amount=-21, category=cat, account=acc1),
+        models.Transaction(date=datetime.date(2021,1,20), label='Unique 01', amount=-5, category=cat, account=acc1),
+        models.Transaction(date=datetime.date(2021,5,10), label='Salary', amount=1000, account=acc1),
+        models.Transaction(date=datetime.date(2021,5,15), label='Groceries', amount=-100, category=cat, account=acc1),
+        models.Transaction(date=datetime.date(2021,5,20), label='Stuff', amount=-30, category=cat, account=acc1),
+        models.Transaction(date=datetime.date(2021,5,5), label='Other', amount=200, account=acc2),
     ])
     session.commit()
+    a1_id = acc1.id
+    a2_id = acc2.id
     session.close()
     with app_module.app.test_client() as client:
-        yield client
+        yield client, a1_id, a2_id
 
 
 def login(client):
@@ -49,11 +53,23 @@ def login(client):
 
 
 def test_recurrents_summary(client):
+    client, a1, a2 = client
     login(client)
     resp = client.get('/stats/recurrents/summary?month=2021-05')
     assert resp.status_code == 200
     data = resp.get_json()
-    assert data['positive'] == pytest.approx(1000)
+    assert data['positive'] == pytest.approx(1200)
     assert data['negative'] == pytest.approx(130)
-    assert data['balance'] == pytest.approx(874)
+    assert data['balance'] == pytest.approx(1124)
     assert data['recurrent'] == pytest.approx(70.5)
+
+
+def test_recurrents_summary_account_filter(client):
+    client, a1, a2 = client
+    login(client)
+    resp = client.get(f'/stats/recurrents/summary?month=2021-05&account_ids={a2}')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['positive'] == pytest.approx(200)
+    assert data['negative'] == pytest.approx(0)
+    assert data['balance'] == pytest.approx(250)


### PR DESCRIPTION
## Summary
- allow filtering recurring stats by bank account
- surface account selectors and month input on cash flow page
- adjust styling for new elements
- test recurring summary filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68722b56519c832f80048a0859e1f87d