### PR TITLE
Ensure navbar buttons match menu header style

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -276,6 +276,10 @@ tbody th {
     padding: 4px 8px;
     border: none;
 }
+#navbar > ul > li > button[data-target] {
+    font-weight: bold;
+    color: var(--text-color);
+}
 #content { flex-grow: 1; padding: 60px 10px 0 10px; }
 
 a {


### PR DESCRIPTION
## Summary
- add style rule so top navbar buttons use the same font weight and default text color as `.menu-header`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872365c5b04832f8ee58f4ed205c119