### PR TITLE
Add missing theme options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,25 @@ l'application sur le réseau local.
 Le cookie de session n'est plus marqué comme sécurisé par défaut. Il est donc
 accepté même en HTTP simple sans configuration supplémentaire.
 
+## Thèmes disponibles
+
+L'interface propose plusieurs feuilles de style sélectionnables depuis le menu
+« Paramètres ». Les thèmes intégrés correspondent aux fichiers CSS suivants :
+
+```
+light.css
+dark.css
+flat-light.css
+flat-dark.css
+luxury-light.css
+luxury-dark.css
+magazine-light.css
+magazine-dark.css
+```
+
+Choisissez simplement le nom de thème désiré dans la liste pour appliquer la
+mise en forme associée.
+
 ## Environnement de développement
 
 Les dépendances principales (**Flask**, **SQLAlchemy**, **Flask-Login**) ainsi que

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -294,6 +294,12 @@
                 <select id="theme-select">
                     <option value="light">Clair</option>
                     <option value="dark">Sombre</option>
+                    <option value="flat-light">Flat clair</option>
+                    <option value="flat-dark">Flat sombre</option>
+                    <option value="luxury-light">Luxe clair</option>
+                    <option value="luxury-dark">Luxe sombre</option>
+                    <option value="magazine-light">Magazine clair</option>
+                    <option value="magazine-dark">Magazine sombre</option>
                 </select>
                 <label for="font-select">Police :</label>
                 <select id="font-select">


### PR DESCRIPTION
## Summary
- list all CSS themes in the theme picker
- document available themes in `README.md`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68724a9f1428832f9dd9c3bc36d538d4