### PR TITLE
Add dynamic theme loading

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1,5 +1,6 @@
 from flask import request, jsonify
 import logging
+import os
 from flask_login import login_required
 from sqlalchemy import func, or_, and_, case
 from datetime import datetime, timedelta  # use standard datetime
@@ -35,6 +36,17 @@ def _parse_account_ids():
 @app.route('/')
 def index():
     return app.send_static_file('index.html')
+
+
+@app.route('/themes')
+def list_themes():
+    """Return available theme names (CSS files in frontend directory)."""
+    files = []
+    for name in os.listdir(app.static_folder):
+        if name.endswith('.css') and name != 'base.css':
+            files.append(name[:-4])
+    files.sort()
+    return jsonify(files)
 
 
 @app.route('/accounts', methods=['GET', 'POST'])

--- a/frontend/index-modif.html
+++ b/frontend/index-modif.html
@@ -265,16 +265,7 @@
                 <ul id="rules-list" style="display:none;"></ul>
                 <h1>Préférences d'affichage</h1>
                 <label for="theme-select">Thème :</label>
-                <select id="theme-select">
-                    <option value="light">Clair</option>
-                    <option value="dark">Sombre</option>
-                    <option value="flat-light">Flat clair</option>
-                    <option value="flat-dark">Flat sombre</option>
-                    <option value="luxury-light">Luxe clair</option>
-                    <option value="luxury-dark">Luxe sombre</option>
-                    <option value="magazine-light">Magazine clair</option>
-                    <option value="magazine-dark">Magazine sombre</option>
-                </select>
+                <select id="theme-select"></select>
                 <label for="font-select">Police :</label>
                 <select id="font-select">
                     <option value="roboto">Roboto</option>
@@ -2802,6 +2793,24 @@
         const dashboardFavOnlyInput = document.getElementById('dashboard-favorites-only');
         const recurrentMonthInput = document.getElementById('recurrent-month');
 
+        async function loadThemes() {
+            try {
+                const resp = await fetch('/themes');
+                if (resp.ok) {
+                    const themes = await resp.json();
+                    themeSelect.innerHTML = '';
+                    themes.forEach(t => {
+                        const opt = document.createElement('option');
+                        opt.value = t;
+                        opt.textContent = t;
+                        themeSelect.appendChild(opt);
+                    });
+                }
+            } catch (e) {
+                console.error('Failed to load themes', e);
+            }
+        }
+
         function applyPreferences() {
             const theme = localStorage.getItem('theme') || 'light';
             const font = localStorage.getItem('font') || 'roboto';
@@ -3021,7 +3030,7 @@
             if (expenseChart) expenseChart.resize();
         });
 
-        applyPreferences();
+        loadThemes().then(applyPreferences);
     </script>
     <script src="sankey.js"></script>
     <script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -291,16 +291,7 @@
                 <ul id="rules-list" style="display:none;"></ul>
                 <h1>Préférences d'affichage</h1>
                 <label for="theme-select">Thème :</label>
-                <select id="theme-select">
-                    <option value="light">Clair</option>
-                    <option value="dark">Sombre</option>
-                    <option value="flat-light">Flat clair</option>
-                    <option value="flat-dark">Flat sombre</option>
-                    <option value="luxury-light">Luxe clair</option>
-                    <option value="luxury-dark">Luxe sombre</option>
-                    <option value="magazine-light">Magazine clair</option>
-                    <option value="magazine-dark">Magazine sombre</option>
-                </select>
+                <select id="theme-select"></select>
                 <label for="font-select">Police :</label>
                 <select id="font-select">
                     <option value="roboto">Roboto</option>
@@ -2828,6 +2819,24 @@
         const dashboardFavOnlyInput = document.getElementById('dashboard-favorites-only');
         const recurrentMonthInput = document.getElementById('recurrent-month');
 
+        async function loadThemes() {
+            try {
+                const resp = await fetch('/themes');
+                if (resp.ok) {
+                    const themes = await resp.json();
+                    themeSelect.innerHTML = '';
+                    themes.forEach(t => {
+                        const opt = document.createElement('option');
+                        opt.value = t;
+                        opt.textContent = t;
+                        themeSelect.appendChild(opt);
+                    });
+                }
+            } catch (e) {
+                console.error('Failed to load themes', e);
+            }
+        }
+
         function applyPreferences() {
             const theme = localStorage.getItem('theme') || 'light';
             const font = localStorage.getItem('font') || 'roboto';
@@ -3047,7 +3056,7 @@
             if (expenseChart) expenseChart.resize();
         });
 
-        applyPreferences();
+        loadThemes().then(applyPreferences);
     </script>
     <script src="sankey.js"></script>
     <script>

--- a/tests/test_themes_endpoint.py
+++ b/tests/test_themes_endpoint.py
@@ -1,0 +1,27 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend import models
+import backend as app_module
+
+
+@pytest.fixture
+def client():
+    engine = create_engine('sqlite:///:memory:')
+    models.engine = engine
+    models.SessionLocal = sessionmaker(bind=engine)
+    app_module.SessionLocal = models.SessionLocal
+    models.init_db()
+    with app_module.app.test_client() as client:
+        yield client
+
+
+def test_themes_endpoint_lists_css_files(client):
+    resp = client.get('/themes')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert 'light' in data
+    assert 'dark' in data
+    assert 'base' not in data


### PR DESCRIPTION
## Summary
- list theme CSS files via new `/themes` endpoint
- fetch available themes on load and apply chosen theme from localStorage
- update both HTML files for dynamic theme list
- test new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876ab931c98832f9a993a98890fbf2c