### PR TITLE
Clear saved future table when changing projection mode

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2928,7 +2928,8 @@
         }
 
         projectionModeInputs.forEach(r => {
-            r.addEventListener('change', () => {
+            r.addEventListener('change', async () => {
+                await clearSavedFutureTable();
                 fetchProjectionFuture();
             });
         });


### PR DESCRIPTION
## Summary
- clear any saved future projection data when toggling projection mode so new mode loads fresh

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6876b8c946dc832faef0db95f8aed81d