### PR TITLE
Update dashboard alerts with numeric reference

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1256,8 +1256,12 @@ def dashboard():
     for tx in recent_txs:
         name = tx.category.name if tx.category else "Inconnu"
         cat_avg = cat_avgs.get(tx.category_id)
-        if cat_avg and abs(tx.amount) > cat_avg * threshold:
-            reason = "category_threshold"
+        if cat_avg:
+            ref = cat_avg * threshold
+        else:
+            ref = None
+        if ref is not None and abs(tx.amount) > ref:
+            reason = ref
         elif abs(tx.amount) > income_avg:
             reason = "income_threshold"
         else:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1538,7 +1538,8 @@
                 const tbody = table.querySelector('tbody');
                 data.alerts.forEach(a => {
                     const tr = document.createElement('tr');
-                    tr.innerHTML = `<td>${formatDate(a.date)}</td><td>${a.label}</td><td class="amount">${formatAmount(a.amount)}</td><td>${a.category}</td><td>${a.reason}</td>`;
+                    const reason = typeof a.reason === 'number' ? formatAmount(a.reason) : a.reason;
+                    tr.innerHTML = `<td>${formatDate(a.date)}</td><td>${a.label}</td><td class="amount">${formatAmount(a.amount)}</td><td>${a.category}</td><td>${reason}</td>`;
                     tbody.appendChild(tr);
                 });
                 container.appendChild(table);

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -60,7 +60,12 @@ def test_dashboard_alerts_and_summaries(client):
     for key in ['date', 'label', 'amount', 'category', 'reason']:
         assert key in first
     huge = [a for a in data['alerts'] if a['label'] == 'Huge expense'][0]
-    assert huge['reason'] == 'category_threshold'
+    session = app_module.SessionLocal()
+    cat = session.query(models.Category).filter_by(name='Food').one()
+    cat_avgs, _ = app_module.compute_dashboard_averages(session, months=3, favorites_only=False)
+    session.close()
+    expected = cat_avgs[cat.id] * 1.5
+    assert huge['reason'] == pytest.approx(expected)
     favs = {}
     cats = {grp['category']: grp for grp in data['favorite_summaries']}
     for grp in data['favorite_summaries']:


### PR DESCRIPTION
## Summary
- compute per-category threshold value in backend
- include this numeric reference in dashboard alerts
- format alert references as amounts on the frontend
- update dashboard tests

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876bcaeff68832fa0ef00700476ac54