### PR TITLE
Fix custom projection rows removal

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2930,8 +2930,7 @@
         }
 
         projectionModeInputs.forEach(r => {
-            r.addEventListener('change', async () => {
-                await clearSavedFutureTable();
+            r.addEventListener('change', () => {
                 fetchProjectionFuture();
             });
         });


### PR DESCRIPTION
## Summary
- keep custom rows when switching projection mode

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876cbae2a44832facac6abdd7dfc5dc