### PR TITLE
Use balance row for projection line

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1617,10 +1617,21 @@
             let running = Number.isFinite(projectionStartBalance)
                 ? projectionStartBalance
                 : 0;
-            barValues.forEach(v => {
-                running += v;
+            projectionData.forEach(d => {
+                running += parseFloat(d.total) || 0;
                 lineValues.push(running);
             });
+            const balanceRow = document.querySelector('#projection-future-table tbody tr.balance-row');
+            if (balanceRow) {
+                balanceRow.querySelectorAll('td.amount').forEach(td => {
+                    lineValues.push(parseAmount(td.textContent));
+                });
+            } else {
+                projectionFutureTotals.forEach(d => {
+                    running += parseFloat(d.total) || 0;
+                    lineValues.push(running);
+                });
+            }
 
             const datasets = [
                 {
@@ -1732,6 +1743,7 @@
                 row.appendChild(td);
             });
             tbody.appendChild(row);
+            drawProjectionChart();
         }
 
         async function saveFutureTable() {


### PR DESCRIPTION
## Summary
- base Solde line on the balance-row values instead of totals
- refresh chart whenever the balance row is updated

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68781ba4fc8c832fb48661afa606db3d