### PR TITLE
Improve projection chart tooltip

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1674,6 +1674,13 @@
             opts.scales.y = opts.scales.y || {};
             opts.scales.x.stacked = true;
             opts.scales.y.stacked = true;
+            opts.plugins = opts.plugins || {};
+            opts.plugins.tooltip = opts.plugins.tooltip || {};
+            opts.plugins.tooltip.callbacks = opts.plugins.tooltip.callbacks || {};
+            opts.plugins.tooltip.callbacks.title = items => {
+                const it = items[0];
+                return [it.dataset.label, it.label];
+            };
 
             projChart = new Chart(ctx, {
                 type: 'bar',


### PR DESCRIPTION
## Summary
- show stacked projection tooltip with category name, date, and amount

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68781a7cc92c832f812cf703cd2746aa