### PR TITLE
Add column mapping support to parse_csv

### DIFF
--- a/tests/test_parse_csv.py
+++ b/tests/test_parse_csv.py
@@ -99,3 +99,26 @@ def test_parse_csv_sanitizes_label(label):
 
     assert not errors
     assert transactions[0]["label"] == "'" + label
+
+
+def test_parse_csv_with_custom_mapping():
+    csv_data = """Compte courant 12345678 2021-01-01
+Achat;Debit;2021-01-02;-12,34;CB
+"""
+    mapping = {
+        'label': 0,
+        'type': 1,
+        'date': 2,
+        'amount': 3,
+        'payment_method': 4,
+    }
+    transactions, duplicates, errors, info = parse_csv(csv_data, mapping=mapping)
+
+    assert not errors
+    assert len(transactions) == 1
+    t = transactions[0]
+    assert t['label'] == 'Achat'
+    assert t['type'] == 'Debit'
+    assert t['payment_method'] == 'CB'
+    assert t['date'] == datetime.date(2021, 1, 2)
+    assert t['amount'] == -12.34


### PR DESCRIPTION
## Summary
- add `mapping` parameter to `parse_csv` to map CSV columns
- adjust duplicate detection logic for flexible column order
- test custom column mapping

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68866ec9e090832fa7995b78579520e9