### PR TITLE
Improve CSV structure detection with data start index

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -222,14 +222,18 @@ def import_preset():
     except Exception as e:
         return jsonify({'error': str(e)}), 400
 
-    delimiter, header_idx, columns = detect_csv_structure(content)
+    delimiter, header_idx, data_start_idx, columns = detect_csv_structure(content)
     lines = content.splitlines()
-    start = header_idx + 1 if header_idx is not None else 0
+    start = data_start_idx
     preview = []
     for row in lines[start:start + 5]:
         if not row.strip():
             continue
         preview.append([c.strip() for c in row.split(delimiter)])
+
+    if not columns and start < len(lines):
+        col_count = len(lines[start].split(delimiter))
+        columns = [f'Colonne {i}' for i in range(1, col_count + 1)]
 
     return jsonify({'columns': columns, 'preview': preview})
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -924,7 +924,7 @@
             return data;
         }
 
-        async function showImportConfig(columns) {
+        async function showImportConfig(columns, previewRows) {
             await fetchImportPresets();
             const tbody = document.querySelector('#import-config-table tbody');
             if (!tbody) return;
@@ -945,6 +945,7 @@
                 { id: 'label', label: 'Libellé' },
                 { id: 'amount', label: 'Montant' }
             ];
+            const sample = Array.isArray(previewRows) && previewRows.length ? previewRows[0] : [];
             fields.forEach(f => {
                 const tr = document.createElement('tr');
                 const tdField = document.createElement('td');
@@ -952,10 +953,14 @@
                 const tdSel = document.createElement('td');
                 const sel = document.createElement('select');
                 sel.dataset.field = f.id;
-                columns.forEach(c => {
+                columns.forEach((c, i) => {
                     const opt = document.createElement('option');
-                    opt.value = c;
-                    opt.textContent = c;
+                    opt.value = i;
+                    if (/^Colonne\s+\d+/i.test(c) && sample[i] !== undefined) {
+                        opt.textContent = sample[i];
+                    } else {
+                        opt.textContent = c;
+                    }
                     sel.appendChild(opt);
                 });
                 tdSel.appendChild(sel);
@@ -1289,7 +1294,7 @@
             selectedCsvFile = fi.files[0];
             const preset = await fetchImportPreset(selectedCsvFile);
             if (preset && preset.columns) {
-                await showImportConfig(preset.columns);
+                await showImportConfig(preset.columns, preset.preview);
             } else {
                 currentImportMapping = null;
                 const prev = await fetchImportPreview(selectedCsvFile, null);
@@ -2877,7 +2882,7 @@
             e.preventDefault();
             const mapping = {};
             document.querySelectorAll('#import-config-table select').forEach(sel => {
-                mapping[sel.dataset.field] = sel.value;
+                mapping[sel.dataset.field] = parseInt(sel.value, 10);
             });
             const name = importConfigNameInput ? importConfigNameInput.value.trim() : '';
             const id = importConfigForm.dataset.presetId;

--- a/tests/test_detect_csv_structure.py
+++ b/tests/test_detect_csv_structure.py
@@ -11,26 +11,29 @@ def test_detect_header_after_blank():
         "2021-01-02;CB;Debit;Achat;-12,34\n"
         "2021-01-03;VIR;Credit;Salaire;1000,00\n"
     )
-    delim, header_idx, cols = detect_csv_structure(csv_data)
+    delim, header_idx, data_idx, cols = detect_csv_structure(csv_data)
     assert delim == ';'
     assert header_idx == 2
+    assert data_idx == 3
     assert cols[0].lower().startswith('date')
     assert cols[-1].lower().startswith('montant')
 
 
 def test_detect_no_header():
     csv_data = """Compte courant 12345678 2021-01-01\n2021-01-02;Debit;CB;Achat;-12,34\n"""
-    delim, header_idx, cols = detect_csv_structure(csv_data)
+    delim, header_idx, data_idx, cols = detect_csv_structure(csv_data)
     assert delim == ';'
     assert header_idx is None
+    assert data_idx == 1
     assert cols == []
 
 
 def test_detect_comma_delimiter():
     csv_data = """Date,Libelle,Montant\n2021-01-02,Achat,-12.34\n"""
-    delim, header_idx, cols = detect_csv_structure(csv_data)
+    delim, header_idx, data_idx, cols = detect_csv_structure(csv_data)
     assert delim == ','
     assert header_idx == 0
+    assert data_idx == 1
     assert cols == ['Date', 'Libelle', 'Montant']
 
 
@@ -40,9 +43,10 @@ def test_detect_tab_delimiter_and_spaces():
         "  Date\t Type \t Montant  \n"
         "2021-01-02\t Debit \t -12.34\n"
     )
-    delim, header_idx, cols = detect_csv_structure(csv_data)
+    delim, header_idx, data_idx, cols = detect_csv_structure(csv_data)
     assert delim == '\t'
     assert header_idx == 1
+    assert data_idx == 2
     assert cols == ['Date', 'Type', 'Montant']
 
 
@@ -52,7 +56,21 @@ def test_detect_pipe_delimiter_with_header_spaces():
         "Date | Libelle | Montant \n"
         "2021-01-02 | Achat | -12.34\n"
     )
-    delim, header_idx, cols = detect_csv_structure(csv_data)
+    delim, header_idx, data_idx, cols = detect_csv_structure(csv_data)
     assert delim == '|'
     assert header_idx == 1
+    assert data_idx == 2
     assert cols == ['Date', 'Libelle', 'Montant']
+
+
+def test_detect_delimiter_from_middle():
+    lines = ["Compte courant 12345678 2021-01-01"]
+    for i in range(5):
+        lines.append(f"2021-01-0{i+2},Achat,-{i+1}.00")
+    for i in range(5, 25):
+        lines.append(f"2021-01-{i+2:02d};Debit;CB;Achat;-{i+1},00")
+    csv_data = "\n".join(lines) + "\n"
+    delim, header_idx, data_idx, cols = detect_csv_structure(csv_data)
+    assert delim == ';'
+    assert header_idx is None
+    assert data_idx == 1

--- a/tests/test_import_preset_endpoint.py
+++ b/tests/test_import_preset_endpoint.py
@@ -42,3 +42,17 @@ def test_import_preset_returns_columns_and_preview(client):
     assert session.query(models.Transaction).count() == 0
     session.close()
 
+
+def test_import_preset_without_header(client):
+    login(client)
+    csv = (
+        "Compte courant 12345678 2021-01-01\n"
+        "2021-01-02;Achat;-12,34\n"
+        "2021-01-03;Test;5,00\n"
+    )
+    resp = send_preset_file(client, csv)
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['columns'] == ['Colonne 1', 'Colonne 2', 'Colonne 3']
+    assert data['preview'][0] == ['2021-01-02', 'Achat', '-12,34']
+


### PR DESCRIPTION
## Summary
- detect CSV data start index in `detect_csv_structure`
- show preview from first transaction line and create generic headers
- show sample values in mapping popup
- test import preset with no headers
- test sniffer sample from the middle of the file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68869ade0788832fa38f43c1ff92e806