### PR TITLE
Fix payment column preview mapping

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -941,7 +941,7 @@
             const fields = [
                 { id: 'date', label: 'Date' },
                 { id: 'type', label: 'Type' },
-                { id: 'payment', label: 'Paiement' },
+                { id: 'payment_method', label: 'Paiement' },
                 { id: 'label', label: 'Libellé' },
                 { id: 'amount', label: 'Montant' }
             ];


### PR DESCRIPTION
## Summary
- fix JS mapping key so payment column is populated during import preview

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886998f5690832fa0a517f7ce2fccfe