### PR TITLE
Handle partial CSV import success

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -869,7 +869,12 @@
             if (mapping) formData.append('mapping', JSON.stringify(mapping));
             const resp = await fetch('/import', { method: 'POST', body: formData });
             const data = await resp.json().catch(() => ({}));
-            if (resp.ok) {
+
+            const success = resp.ok || (typeof data.imported === 'number' && data.imported > 0);
+            if (success) {
+                if (data.errors) {
+                    alert(data.errors.join('\n'));
+                }
                 if (data.account) {
                     selectedAccountId = data.account.id;
                 }
@@ -879,14 +884,7 @@
                 if (data.duplicates && data.duplicates.length) {
                     showDuplicates(data.duplicates, data.account ? data.account.id : '');
                 } else {
-                    fetchTransactions();
-                    fetchDashboard();
-                    fetchStats();
-                    fetchProjection();
-                    fetchProjectionCategories();
-                    fetchProjectionFuture();
-                    fetchCategoryStats();
-                    fetchSankeyStats();
+                    refreshAll();
                 }
             } else {
                 if (data.errors) {
@@ -895,6 +893,17 @@
                     alert(data.error || 'Erreur import');
                 }
             }
+        }
+
+        function refreshAll() {
+            fetchTransactions();
+            fetchDashboard();
+            fetchStats();
+            fetchProjection();
+            fetchProjectionCategories();
+            fetchProjectionFuture();
+            fetchCategoryStats();
+            fetchSankeyStats();
         }
 
         let selectedCsvFile = null;
@@ -2947,7 +2956,12 @@
             dupOverlay.style.display = 'flex';
         }
 
-        dupOverlay.addEventListener('click', e => { if (e.target === dupOverlay) dupOverlay.style.display = 'none'; });
+        dupOverlay.addEventListener('click', e => {
+            if (e.target === dupOverlay) {
+                dupOverlay.style.display = 'none';
+                refreshAll();
+            }
+        });
         document.getElementById('duplicate-form').addEventListener('submit', async e => {
             e.preventDefault();
             const rows = JSON.parse(dupOverlay.dataset.rows || '[]');
@@ -2957,14 +2971,7 @@
             });
             dupOverlay.style.display = 'none';
             if (!selected.length) {
-                fetchTransactions();
-                fetchDashboard();
-                fetchStats();
-                fetchProjection();
-                fetchProjectionCategories();
-                fetchProjectionFuture();
-                fetchCategoryStats();
-                fetchSankeyStats();
+                refreshAll();
                 return;
             }
             const resp = await fetch('/import/confirm', {
@@ -2974,14 +2981,7 @@
             });
             const data = await resp.json().catch(() => ({}));
             if (resp.ok) {
-                fetchTransactions();
-                fetchDashboard();
-                fetchStats();
-                fetchProjection();
-                fetchProjectionCategories();
-                fetchProjectionFuture();
-                fetchCategoryStats();
-                fetchSankeyStats();
+                refreshAll();
             } else {
                 if (data.errors) alert(data.errors.join('\n')); else alert(data.error || 'Erreur import');
             }


### PR DESCRIPTION
## Summary
- show errors from CSV import even on partial success
- refresh UI when CSV import partially succeeds or duplicates are dismissed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886a395e6d8832f813844e2f45c50c9