### PR TITLE
Improve category update UX with delayed refresh

### DIFF
--- a/frontend/index-modif.html
+++ b/frontend/index-modif.html
@@ -384,6 +384,8 @@
         let projectionAccountIds = [];
         let projectionStartBalance = 0;
         let activeFutureCell = null;
+        let pendingCatChange = false;
+        let pendingSubChange = false;
 
         function showLoginForm() {
             document.getElementById('app').style.display = 'none';
@@ -2664,7 +2666,18 @@
                     currentCatBtn.textContent = '(Aucune)';
                     currentCatBtn.style.color = '';
                 }
-                fetchTransactions();
+                const fc = document.getElementById('filter-category').value;
+                const fs = document.getElementById('filter-subcategory').value;
+                if (fc || fs) {
+                    pendingCatChange = true;
+                    if (pendingSubChange) {
+                        pendingCatChange = false;
+                        pendingSubChange = false;
+                        fetchTransactions();
+                    }
+                } else {
+                    fetchTransactions();
+                }
             }
             catOverlay.style.display = 'none';
             currentCatBtn = null;
@@ -2693,7 +2706,18 @@
                     currentSubBtn.textContent = '(Aucune)';
                     currentSubBtn.style.color = '';
                 }
-                fetchTransactions();
+                const fc = document.getElementById('filter-category').value;
+                const fs = document.getElementById('filter-subcategory').value;
+                if (fc || fs) {
+                    pendingSubChange = true;
+                    if (pendingCatChange) {
+                        pendingCatChange = false;
+                        pendingSubChange = false;
+                        fetchTransactions();
+                    }
+                } else {
+                    fetchTransactions();
+                }
             }
             subOverlay.style.display = 'none';
             currentSubBtn = null;
@@ -2960,16 +2984,17 @@
         filterInputs.forEach(id => {
             const el = document.getElementById(id);
             if (el) {
-                el.addEventListener('input', () => {
+                const handler = () => {
+                    if (id === 'filter-category' || id === 'filter-subcategory') {
+                        pendingCatChange = false;
+                        pendingSubChange = false;
+                    }
                     fetchTransactions();
                     fetchCategoryStats();
                     fetchSankeyStats();
-                });
-                el.addEventListener('change', () => {
-                    fetchTransactions();
-                    fetchCategoryStats();
-                    fetchSankeyStats();
-                });
+                };
+                el.addEventListener('input', handler);
+                el.addEventListener('change', handler);
             }
         });
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -454,6 +454,8 @@
         let activeFutureCell = null;
         let importPresetsData = [];
         let currentImportMapping = null;
+        let pendingCatChange = false;
+        let pendingSubChange = false;
 
         function showLoginForm() {
             document.getElementById('app').style.display = 'none';
@@ -3012,7 +3014,18 @@
                     currentCatBtn.textContent = '(Aucune)';
                     currentCatBtn.style.color = '';
                 }
-                fetchTransactions();
+                const fc = document.getElementById('filter-category').value;
+                const fs = document.getElementById('filter-subcategory').value;
+                if (fc || fs) {
+                    pendingCatChange = true;
+                    if (pendingSubChange) {
+                        pendingCatChange = false;
+                        pendingSubChange = false;
+                        fetchTransactions();
+                    }
+                } else {
+                    fetchTransactions();
+                }
             }
             catOverlay.style.display = 'none';
             currentCatBtn = null;
@@ -3041,7 +3054,18 @@
                     currentSubBtn.textContent = '(Aucune)';
                     currentSubBtn.style.color = '';
                 }
-                fetchTransactions();
+                const fc = document.getElementById('filter-category').value;
+                const fs = document.getElementById('filter-subcategory').value;
+                if (fc || fs) {
+                    pendingSubChange = true;
+                    if (pendingCatChange) {
+                        pendingCatChange = false;
+                        pendingSubChange = false;
+                        fetchTransactions();
+                    }
+                } else {
+                    fetchTransactions();
+                }
             }
             subOverlay.style.display = 'none';
             currentSubBtn = null;
@@ -3308,16 +3332,17 @@
         filterInputs.forEach(id => {
             const el = document.getElementById(id);
             if (el) {
-                el.addEventListener('input', () => {
+                const handler = () => {
+                    if (id === 'filter-category' || id === 'filter-subcategory') {
+                        pendingCatChange = false;
+                        pendingSubChange = false;
+                    }
                     fetchTransactions();
                     fetchCategoryStats();
                     fetchSankeyStats();
-                });
-                el.addEventListener('change', () => {
-                    fetchTransactions();
-                    fetchCategoryStats();
-                    fetchSankeyStats();
-                });
+                };
+                el.addEventListener('input', handler);
+                el.addEventListener('change', handler);
             }
         });
 


### PR DESCRIPTION
## Summary
- add `pendingCatChange` and `pendingSubChange` flags
- delay table refresh when category or subcategory is edited while filters are active
- reset pending flags when category/subcategory filters change

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68871e622f90832f9d17e64bdf1fea42