### PR TITLE
fix: delay select opening to after popup

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2762,13 +2762,13 @@
                 currentCatBtn = e.target;
                 document.getElementById('popup-category-select').value = currentCatBtn.dataset.current || '';
                 showPopupAt(catOverlay, e.clientX, e.clientY);
-                openSelect('popup-category-select');
+                requestAnimationFrame(() => openSelect('popup-category-select'));
             } else if (e.target.classList.contains('tx-sub-btn')) {
                 currentSubBtn = e.target;
                 populateSubPopup(currentSubBtn.dataset.categoryId);
                 document.getElementById('popup-subcategory-select').value = currentSubBtn.dataset.current || '';
                 showPopupAt(subOverlay, e.clientX, e.clientY);
-                openSelect('popup-subcategory-select');
+                requestAnimationFrame(() => openSelect('popup-subcategory-select'));
             } else if (e.target.classList.contains('tx-rule-btn')) {
                 currentRuleBtn = e.target;
                 const label = currentRuleBtn.dataset.label || '';


### PR DESCRIPTION
## Summary
- ensure category/subcategory selectors open after popup renders by wrapping `openSelect` in `requestAnimationFrame`

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c6feaa3248832fbfde408aacbc566d