### PR TITLE
feat: keep transactions table headers visible

### DIFF
--- a/frontend/base.css
+++ b/frontend/base.css
@@ -57,6 +57,7 @@ tbody th {
     font-size: 0.85rem;
     width: 95%;
     table-layout: auto;
+    --transactions-filter-row-height: 4.25rem;
 }
 #transactions-table.long-label {
     font-size: 0.75rem;
@@ -66,6 +67,22 @@ tbody th {
 }
 #transactions-table th {
     white-space: normal;
+}
+
+#transactions-table thead tr:nth-child(1),
+#transactions-table thead tr:nth-child(2) {
+    position: sticky;
+    background-color: var(--table-header-bg);
+    z-index: 2;
+}
+
+#transactions-table thead tr:nth-child(1) {
+    top: 0;
+    z-index: 3;
+}
+
+#transactions-table thead tr:nth-child(2) {
+    top: var(--transactions-filter-row-height);
 }
 
 /* Filter row inside transactions table */


### PR DESCRIPTION
## Summary
- keep first two rows of the transactions table header sticky
- ensure sticky rows remain visible via background and z-index

## Testing
- `node /tmp/test-sticky.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6ffd8b9b0832fb4760baf8c073af0